### PR TITLE
feat: create buffconf-specific functions for indexing and searching within turbopuffer

### DIFF
--- a/momento-functions/Cargo.toml
+++ b/momento-functions/Cargo.toml
@@ -35,7 +35,15 @@ name = "turbopuffer-index"
 crate-type = ["cdylib"]
 
 [[example]]
+name = "turbopuffer-index-articles"
+crate-type = ["cdylib"]
+
+[[example]]
 name = "turbopuffer-search"
+crate-type = ["cdylib"]
+
+[[example]]
+name = "turbopuffer-search-articles"
 crate-type = ["cdylib"]
 
 [[example]]

--- a/momento-functions/examples/turbopuffer-index-articles.rs
+++ b/momento-functions/examples/turbopuffer-index-articles.rs
@@ -1,0 +1,329 @@
+//! Using input data from CBS Sports articles, this function will
+//! query OpenAI to generate embeddings for each document, then index it
+//! within Turbopuffer so we can search through it. To make things even faster,
+//! we'll use Momento in-host caching for the embedding queries.
+//!
+//! You need to provide `OPENAI_KEY`, `TURBOPUFFER_ENDPOINT`, and `TURBOPUFFER_API_KEY`
+//! environment variables when creating this function:
+//! * `OPENAI_KEY`              -> The API key for accessing OpenAI, shoud just be the key itself.
+//! * `TURBOPUFFER_ENDPOINT`    -> The endpoint contains the namespace.
+//! * `TURBOPUFFER_API_KEY`     -> The API key should just be the key itself.
+//!
+//! You can also provide the `TTL_SECONDS` environment variable to override the default
+//! ttl used to store embeddings in your Momento cache.
+//!
+//! To demo this, you can pipe a subset of the data and feed it into a cURL command
+//! to invoke your function:
+//! ```bash
+//! # Export your environment variables
+//! export MOMENTO_CELL_HOSTNAME=<momento cell>
+//! export MOMENTO_CACHE_NAME=my-functions-cache
+//! export MOMENTO_API_KEY=<your api key>
+//!
+//! export OPENAI_KEY=<openai api key>
+//! export TURBOPUFFER_ENDPOINT=<Should be v2 namespace>
+//! export TURBOPUFFER_API_KEY=<turbopuffer api key>
+//!
+//! # Create your Momento cache
+//! momento cache create $MOMENTO_CACHE_NAME
+//!
+//! # Create your Momento function
+//! momento preview function put-function \
+//!   --cache-name "$MOMENTO_CACHE_NAME" \
+//!   --name turbopuffer-index-articles \
+//!   --wasm-file /path/to/this/compiled/turbopuffer_index_articles.wasm \
+//!   -E OPENAI_KEY="$OPENAI_KEY" \
+//!   -E TURBOPUFFER_ENDPOINT="$TURBOPUFFER_ENDPOINT" \
+//!   -E TURBOPUFFER_API_KEY="$TURBOPUFFER_API_KEY"
+//!
+//! # Send subset of articles for indexing via our uploaded function
+//! jq 'articles.nba' /path/to/your/data.json | curl \
+//!   curl https://api.cache.$MOMENTO_CELL_HOSTNAME/functions/$MOMENTO_CACHE_NAME/turbopuffer-index-articles \
+//!   -XPOST \
+//!   -H "authorization: $MOMENTO_API_KEY" \
+//!   -H "Content-Type: application/json" \
+//!   -d @-   
+//! ```
+
+use std::time::Duration;
+
+use itertools::Itertools;
+use log::LevelFilter;
+use momento_functions::{WebError, WebResponse, WebResult};
+use momento_functions_host::{cache, encoding::Json, web_extensions::headers};
+use momento_functions_log::LogMode;
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+
+#[derive(Deserialize, Debug)]
+struct EmbeddingResponse {
+    data: Vec<EmbeddingData>,
+}
+#[derive(Deserialize, Serialize, Debug)]
+struct EmbeddingData {
+    embedding: Vec<f32>,
+    index: usize,
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+struct QueryRow {
+    #[serde(alias = "$dist")]
+    dist: f32,
+    id: String,
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+struct DocumentMetadata {
+    title: String,
+    link: String,
+    authors: Vec<String>,
+    language: String,
+    description: String,
+    feed: String,
+}
+
+#[derive(Deserialize, Debug)]
+struct DocumentInput {
+    id: String,
+    #[serde(alias = "metadata")]
+    document_metadata: DocumentMetadata,
+    page_content: String,
+}
+
+impl DocumentInput {
+    pub fn into_turbopuffer_document(self, vector: Vec<f32>) -> TurbopufferDocument {
+        TurbopufferDocument {
+            id: self.id,
+            page_content: self.page_content,
+            vector,
+            // Flatten out the dimensions
+            metadata_title: self.document_metadata.title,
+            metadata_link: self.document_metadata.link,
+            metadata_authors: self.document_metadata.authors,
+            metadata_language: self.document_metadata.language,
+            metadata_description: self.document_metadata.description,
+            metadata_feed: self.document_metadata.feed,
+        }
+    }
+}
+
+#[derive(Serialize, Debug)]
+struct TurbopufferDocument {
+    id: String,
+    page_content: String,
+    vector: Vec<f32>,
+    // Flatten out the dimensions for easy query
+    #[serde(rename = "metadata$title")]
+    metadata_title: String,
+    #[serde(rename = "metadata$link")]
+    metadata_link: String,
+    #[serde(rename = "metadata$authors")]
+    metadata_authors: Vec<String>,
+    #[serde(rename = "metadata$language")]
+    metadata_language: String,
+    #[serde(rename = "metadata$description")]
+    metadata_description: String,
+    #[serde(rename = "metadata$feed")]
+    metadata_feed: String,
+}
+
+const DEFAULT_TTL_SECONDS: u64 = 30;
+
+momento_functions::post!(index_document);
+fn index_document(Json(documents): Json<Vec<DocumentInput>>) -> WebResult<WebResponse> {
+    let headers = headers();
+    setup_logging(&headers)?;
+
+    if documents.is_empty() {
+        log::warn!("No documents provided for indexing.");
+        return Ok(WebResponse::new()
+            .with_status(400)
+            .with_body("No documents provided")?);
+    }
+
+    // These are passed in as environment variables when creating the function
+    let turbopuffer_api_key = format!(
+        "Bearer {}",
+        std::env::var("TURBOPUFFER_API_KEY").unwrap_or_default()
+    );
+    let turbopuffer_endpoint = std::env::var("TURBOPUFFER_ENDPOINT").unwrap_or_default();
+    let openapi_key = std::env::var("OPENAI_KEY").unwrap_or_default();
+
+    // Not required, but can be overridden
+    let ttl_seconds = std::env::var("TTL_SECONDS")
+        .unwrap_or_default()
+        .parse::<u64>()
+        .unwrap_or(DEFAULT_TTL_SECONDS);
+
+    let chunks = documents.into_iter().chunks(2000);
+    for chunk in chunks.into_iter() {
+        let chunk: Vec<DocumentInput> = chunk.collect();
+        // Queries OpenAI to generate an embedding for this document so we can ship it off to Turbopuffer
+        let mut turbopuffer_inputs = Vec::new();
+        for document in chunk {
+            log::debug!("getting embedding for id {}", document.id);
+            let embedding = get_cached_query_embedding(
+                document.page_content.clone(),
+                ttl_seconds,
+                openapi_key.clone(),
+            )?;
+            turbopuffer_inputs.push(document.into_turbopuffer_document(embedding));
+        }
+        log::debug!("sending to turbopuffer: {}", json!(turbopuffer_inputs));
+        // Send off our transformed data to Turbopuffer, complete with embeddings
+        let result = momento_functions_host::http::post(
+            turbopuffer_endpoint.clone(),
+            [
+                ("Authorization".to_string(), turbopuffer_api_key.clone()),
+                ("Content-Type".to_string(), "application/json".to_string()),
+                ("Accept".to_string(), "*/*".to_string()),
+                (
+                    "User-Agent".to_string(),
+                    "momento-turbobuffer-example".to_string(),
+                ),
+            ],
+            json!({
+                "upsert_rows": turbopuffer_inputs,
+                "distance_metric": "cosine_distance",
+            }),
+        );
+        match result {
+            Ok(response) => {
+                log::debug!("turbopuffer response: {:?}", response.headers);
+                if response.status != 200 {
+                    let message = format!(
+                        "Failed to index documents: {}",
+                        String::from_utf8(response.body).unwrap_or_default(),
+                    );
+                    return Ok(WebResponse::new().with_status(response.status).with_body(
+                        json!({
+                            "message": message,
+                        }),
+                    )?);
+                }
+            }
+            Err(e) => {
+                log::error!("Failed to index documents: {e:?}");
+                return Ok(WebResponse::new().with_status(500).with_body(json!({
+                    "message": e.to_string(),
+                }))?);
+            }
+        }
+    }
+    Ok(WebResponse::new().with_status(200).with_body(json!({
+        "message": "Documents indexed successfully",
+    }))?)
+}
+
+// ------------------------------------------------------
+// | Utility functions for convenience
+// ------------------------------------------------------
+
+fn get_cached_query_embedding(
+    query: String,
+    ttl_seconds: u64,
+    openai_key: String,
+) -> WebResult<Vec<f32>> {
+    log::debug!("Checking if embeddings are already cached for input");
+    Ok(match cache::get::<Vec<u8>>(query.clone())? {
+        Some(hit) => {
+            log::debug!("cache hit");
+            // Convert raw bytes back into our Vec<f32> type
+            hit.chunks_exact(4)
+                .map(|chunk| {
+                    let arr = <[u8; 4]>::try_from(chunk)
+                        .map_err(|_| WebError::message("Chunk length should be 4"))?;
+                    Ok(f32::from_le_bytes(arr))
+                })
+                .collect::<Result<Vec<f32>, WebError>>()?
+        }
+        None => {
+            log::debug!("cache miss, querying embeddings from open ai");
+            match get_embeddings(query.clone(), openai_key)?
+                .into_iter()
+                .next()
+            {
+                Some(embedding) => {
+                    // Convert to raw bytes before storing in cache
+                    let new_query_embedding = embedding
+                        .embedding
+                        .clone()
+                        .into_iter()
+                        .flat_map(f32::to_le_bytes)
+                        .collect::<Vec<u8>>();
+                    log::debug!("setting embeddings in cache");
+                    cache::set(
+                        query,
+                        new_query_embedding.clone(),
+                        Duration::from_secs(ttl_seconds),
+                    )?;
+                    embedding.embedding
+                }
+                None => {
+                    log::error!("Failed to get embedding for query: {query}");
+                    return Err(WebError::message("Failed to get embedding for query"));
+                }
+            }
+        }
+    })
+}
+
+fn get_embeddings(query: String, openai_key: String) -> WebResult<Vec<EmbeddingData>> {
+    log::debug!("getting embeddings for input");
+    let query = if query.contains("\n") {
+        // openai guide currently says to replace newlines with spaces. This, then, must be how you get the cargo to come.
+        // https://platform.openai.com/docs/guides/embeddings
+        query.replace("\n", " ")
+    } else {
+        query
+    };
+
+    // openai will fail to generate an embedding if no content is provided
+    let query = if query.is_empty() {
+        "no content".to_string()
+    } else {
+        query
+    };
+
+    let result = momento_functions_host::http::post(
+        "https://api.openai.com/v1/embeddings",
+        [
+            ("authorization".to_string(), format!("Bearer {openai_key}")),
+            ("content-type".to_string(), "application/json".to_string()),
+        ],
+        // 1536 float32 for text-embedding-3-small
+        serde_json::json!({
+            "model": "text-embedding-3-small",
+            "encoding_format": "float",
+            "input": [query],
+        })
+        .to_string(),
+    );
+    let mut response = result?;
+    log::debug!("OpenAI response: {:?}", response.headers);
+    let Json(EmbeddingResponse { mut data }) = response.extract()?;
+    data.sort_by_key(|d| d.index);
+    Ok(data)
+}
+
+fn setup_logging(headers: &[(String, String)]) -> WebResult<()> {
+    let log_level = headers.iter().find_map(|(name, value)| {
+        if name == "x-momento-log" {
+            Some(value)
+        } else {
+            None
+        }
+    });
+    if let Some(log_level) = log_level {
+        let log_level = log_level
+            .parse::<LevelFilter>()
+            .unwrap_or(LevelFilter::Info);
+        momento_functions_log::configure_logging(
+            log_level,
+            LogMode::Topic {
+                topic: "turbopuffer-index-articles".to_string(),
+            },
+        )?;
+    }
+    Ok(())
+}

--- a/momento-functions/examples/turbopuffer-search-articles.rs
+++ b/momento-functions/examples/turbopuffer-search-articles.rs
@@ -1,0 +1,406 @@
+//! After we've indexed data using `turbopuffer-index-articles.rs`, this function will
+//! query OpenAI to generate embeddings for our search text, then query our
+//! Turbopuffer namespace using a nearest-neighbor search. To speed things up,
+//! we'll use Momento in-host caching for the embedding queries.
+//!
+//! You need to provide `OPENAI_KEY`, `TURBOPUFFER_ENDPOINT`, and `TURBOPUFFER_API_KEY`
+//! environment variables when creating this function:
+//! * `OPENAI_KEY`              -> The API key for accessing OpenAI, shoud just be the key itself.
+//! * `TURBOPUFFER_ENDPOINT`    -> The endpoint contains the namespace. Ensure it ends with `/query`
+//! * `TURBOPUFFER_API_KEY`     -> The API key should just be the key itself.
+//!
+//! You can also provide the `TTL_SECONDS` environment variable to override the default
+//! ttl used to store embeddings in your Momento cache.
+//!
+//! To demo this, you can create your function and then pipe your search query as JSON
+//! into your function. See Turbopuffer's Query docs page for example filters:
+//! https://turbopuffer.com/docs/query#param-filters
+//!
+//! ```bash
+//! # Export your environment variables
+//! export MOMENTO_CELL_HOSTNAME=<momento cell>
+//! export MOMENTO_CACHE_NAME=my-functions-cache
+//! export MOMENTO_API_KEY=<your api key>
+//!
+//! export OPENAI_KEY=<openai api key>
+//! export TURBOPUFFER_ENDPOINT=<Should be v2 namespace>
+//! export TURBOPUFFER_API_KEY=<turbopuffer api key>
+//!
+//! # Create your Momento cache
+//! momento cache create $MOMENTO_CACHE_NAME
+//!
+//! # Create your Momento function
+//! momento preview function put-function \
+//!   --cache-name "$MOMENTO_CACHE_NAME" \
+//!   --name turbopuffer-search-articles \
+//!   --wasm-file /path/to/this/compiled/turbopuffer_search_articles.wasm \
+//!   -E OPENAI_KEY="$OPENAI_KEY" \
+//!   -E TURBOPUFFER_ENDPOINT="$TURBOPUFFER_ENDPOINT" \
+//!   -E TURBOPUFFER_API_KEY="$TURBOPUFFER_API_KEY"
+//!
+//! # Perform a basic text search
+//! curl --silent \
+//! https://api.cache.$MOMENTO_CELL_HOSTNAME/functions/$MOMENTO_CACHE_NAME/turbopuffer-search-articles \
+//!  -H "authorization: $MOMENTO_API_KEY" \
+//!  -H "Content-Type: application/json" \
+//!  -d '{"topk": 5, "query": "Portland Trail Blazers", "include_attributes": ["metadata$title", "metadata$link"]}'  | jq
+//!
+//! # Filter out entries that include a glob, and filter out a specific ID
+//! read -r -d '' payload << EOM
+//! {
+//!  "topk": 25,
+//!  "query": "Portland Trail Blazers",
+//!  "include_attributes": [
+//!    "metadata\$title",
+//!    "metadata\$link"
+//!  ],
+//!  "filters": [
+//!    "And",
+//!    [
+//!      ["metadata\$title", "NotGlob", "*Mock Draft*"],
+//!      ["Not", ["id", "In", ["11782925380870169755"]]]
+//!    ]
+//!  ]
+//! }
+//! EOM
+//! curl --silent \
+//!  https://api.cache.$MOMENTO_CELL_HOSTNAME/functions/$MOMENTO_CACHE_NAME/turbopuffer-search-articles \
+//!  -H "authorization: $MOMENTO_API_KEY" \
+//!  -H "Content-Type: application/json" \
+//!  -d "$payload" | jq
+//!
+//! # Now do the same thing, but use `jq` to reduce articles with a cosine distance <= 0.6
+//! read -r -d '' payload << EOM
+//! {
+//!  "topk": 25,
+//!  "query": "Portland Trail Blazers",
+//!  "include_attributes": [
+//!    "metadata\$title",
+//!    "metadata\$link"
+//!  ],
+//!  "filters": [
+//!    "And",
+//!    [
+//!      ["metadata\$title", "NotGlob", "*Mock Draft*"],
+//!      ["Not", ["id", "In", ["11782925380870169755"]]]
+//!    ]
+//!  ]
+//! }
+//! EOM
+//! curl --silent \
+//!  https://api.cache.$MOMENTO_CELL_HOSTNAME/functions/$MOMENTO_CACHE_NAME/turbopuffer-search-articles \
+//!  -H "authorization: $MOMENTO_API_KEY" \
+//!  -H "Content-Type: application/json" \
+//!  -d "$payload" | \
+//! jq '[.[] | select(.dist <= 0.6)]'
+//! ```
+
+use std::time::Duration;
+
+use log::LevelFilter;
+
+use momento_functions::{WebError, WebResponse, WebResult};
+use momento_functions_host::{cache, encoding::Json, web_extensions::headers};
+use momento_functions_log::LogMode;
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+
+#[derive(Deserialize, Debug)]
+struct Request {
+    query: String,
+    topk: Option<usize>,
+    include_attributes: Option<Vec<String>>,
+    filters: Option<Filter>,
+}
+
+#[derive(Deserialize, Debug)]
+struct EmbeddingResponse {
+    data: Vec<EmbeddingData>,
+}
+#[derive(Deserialize, Serialize, Debug)]
+struct EmbeddingData {
+    embedding: Vec<f32>,
+    index: usize,
+}
+
+#[derive(Deserialize, Debug)]
+struct QueryResponse {
+    rows: Vec<QueryRow>,
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+struct QueryRow {
+    #[serde(alias = "$dist")]
+    dist: f32,
+    id: String,
+    // See example in `turbopuffer-index-articles.rs`.
+    // If we specify attributes in `include_attributes`, we
+    // want to deserialize those in our response body
+    #[serde(skip_serializing_if = "Option::is_none")]
+    vector: Option<Vec<f32>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    page_content: Option<String>,
+    #[serde(rename = "metadata$title")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    metadata_title: Option<String>,
+    #[serde(rename = "metadata$link")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    metadata_link: Option<String>,
+    #[serde(rename = "metadata$authors")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    metadata_authors: Option<Vec<String>>,
+    #[serde(rename = "metadata$language")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    metadata_language: Option<String>,
+    #[serde(rename = "metadata$description")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    metadata_description: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "metadata$feed")]
+    metadata_feed: Option<String>,
+}
+
+// Default to 30 second caching time for queries in Momento
+const DEFAULT_TTL_SECONDS: u64 = 30;
+
+momento_functions::post!(search);
+fn search(Json(request): Json<Request>) -> WebResult<WebResponse> {
+    let headers = headers();
+    setup_logging(&headers)?;
+
+    let Request {
+        query,
+        topk,
+        include_attributes,
+        filters,
+    } = request;
+    // Transform our human-readable text into embeddings via OpenAI
+    let embeddings = get_cached_query_embedding(query)?;
+    // Default to top 5 results if not provided
+    let topk = topk.unwrap_or(5);
+    // Default to empty list if not provided
+    let include_attributes = include_attributes.unwrap_or_default();
+
+    // These are passed in as environment variables when creating the function
+    let turbopuffer_api_key = format!(
+        "Bearer {}",
+        std::env::var("TURBOPUFFER_API_KEY").unwrap_or_default()
+    );
+    let turbopuffer_endpoint = std::env::var("TURBOPUFFER_ENDPOINT").unwrap_or_default();
+
+    log::debug!(
+        "querying turbopuffer with (topk={topk}), (include_attributes={:?})",
+        include_attributes
+    );
+    let result = momento_functions_host::http::post(
+        turbopuffer_endpoint,
+        [
+            ("Authorization".to_string(), turbopuffer_api_key.to_string()),
+            ("Content-Type".to_string(), "application/json".to_string()),
+            ("Accept".to_string(), "*/*".to_string()),
+            (
+                "User-Agent".to_string(),
+                "momento-turbobuffer-example".to_string(),
+            ),
+        ],
+        json!({
+            "rank_by": ["vector", "ANN", embeddings],
+            "top_k": topk,
+            "include_attributes": include_attributes,
+            "filters": filters,
+        }),
+    );
+    match result {
+        Ok(mut response) => {
+            log::debug!("Turbopuffer response: {:?}", response.headers);
+            if response.status != 200 {
+                let message = format!(
+                    "Failed to search documents: {}",
+                    String::from_utf8(response.body).unwrap_or_default(),
+                );
+                return Ok(WebResponse::new()
+                    .with_status(response.status)
+                    .with_body(json!({
+                        "message": message,
+                    }))?);
+            }
+            let raw = String::from_utf8(response.body.clone()).unwrap_or_default();
+            // You can set this to debug if you'd like to see what Turbopuffer is sending back
+            log::trace!("Turbopuffer response body: {:?}", raw);
+            // Just get the data we care about, no need to report back Turbopuffer timings/billing info
+            let Json(QueryResponse { rows }) = response.extract()?;
+            let response_body = serde_json::to_vec(&rows)?;
+            Ok(WebResponse::new()
+                .with_status(200)
+                .with_headers(vec![(
+                    "Content-Type".to_string(),
+                    "application/json".to_string(),
+                )])
+                .with_body(response_body)?)
+        }
+        Err(e) => {
+            log::error!("Failed to search documents: {e:?}");
+            Ok(WebResponse::new().with_status(500).with_body(json!({
+                "message": e.to_string(),
+            }))?)
+        }
+    }
+}
+
+// ------------------------------------------------------
+// | Utility functions for convenience
+// ------------------------------------------------------
+
+fn get_cached_query_embedding(query: String) -> WebResult<Vec<f32>> {
+    log::debug!("Checking if embeddings are already cached for \"{query}\"");
+    Ok(match cache::get::<Vec<u8>>(query.clone())? {
+        Some(hit) => {
+            log::debug!("cache hit");
+            // Convert raw bytes back into our Vec<f32> type
+            hit.chunks_exact(4)
+                .map(|chunk| {
+                    let arr = <[u8; 4]>::try_from(chunk)
+                        .map_err(|_| WebError::message("Chunk length should be 4"))?;
+                    Ok(f32::from_le_bytes(arr))
+                })
+                .collect::<Result<Vec<f32>, WebError>>()?
+        }
+        None => {
+            log::debug!("cache miss, querying embeddings from open ai");
+            match get_embeddings(query.clone())?.into_iter().next() {
+                Some(embedding) => {
+                    // Convert to raw bytes before storing in cache
+                    let new_query_embedding = embedding
+                        .embedding
+                        .clone()
+                        .into_iter()
+                        .flat_map(f32::to_le_bytes)
+                        .collect::<Vec<u8>>();
+                    let ttl: u64 = std::env::var("TTL")
+                        .unwrap_or("".to_string())
+                        .parse::<u64>()
+                        .unwrap_or(DEFAULT_TTL_SECONDS);
+                    cache::set(query, new_query_embedding.clone(), Duration::from_secs(ttl))?;
+                    embedding.embedding
+                }
+                None => {
+                    log::error!("Failed to get embedding for query: {query}");
+                    return Err(WebError::message("Failed to get embedding for query"));
+                }
+            }
+        }
+    })
+}
+
+fn get_embeddings(query: String) -> WebResult<Vec<EmbeddingData>> {
+    log::debug!("getting embeddings for document with content: {query:?}");
+    let query = if query.contains("\n") {
+        // openai guide currently says to replace newlines with spaces. This, then, must be how you get the cargo to come.
+        // https://platform.openai.com/docs/guides/embeddings
+        query.replace("\n", " ")
+    } else {
+        query
+    };
+
+    // Required to be set as an environment variable when creating the function
+    let openapi_key = std::env::var("OPENAI_KEY").unwrap_or_default();
+    let result = momento_functions_host::http::post(
+        "https://api.openai.com/v1/embeddings",
+        [
+            ("authorization".to_string(), format!("Bearer {openapi_key}")),
+            ("content-type".to_string(), "application/json".to_string()),
+        ],
+        // 1536 float32 for text-embedding-3-small
+        serde_json::json!({
+            "model": "text-embedding-3-small",
+            "encoding_format": "float",
+            "input": [query],
+        })
+        .to_string(),
+    );
+    let mut response = result?;
+    log::debug!("OpenAI response: {:?}", response.headers);
+    let Json(EmbeddingResponse { mut data }) = response.extract()?;
+    data.sort_by_key(|d| d.index);
+    log::trace!("OpenAI extracted data: {data:?}");
+    Ok(data)
+}
+
+fn setup_logging(headers: &[(String, String)]) -> WebResult<()> {
+    let log_level = headers.iter().find_map(|(name, value)| {
+        if name == "x-momento-log" {
+            Some(value)
+        } else {
+            None
+        }
+    });
+    if let Some(log_level) = log_level {
+        let log_level = log_level
+            .parse::<LevelFilter>()
+            .unwrap_or(LevelFilter::Info);
+        momento_functions_log::configure_logging(
+            log_level,
+            LogMode::Topic {
+                topic: "turbopuffer-search-articles".to_string(),
+            },
+        )?;
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// | Utility structs when de/serializing filtering args for Turbopuffer
+// ---------------------------------------------------------------------------
+
+// Recursive struct without any validation, Turbopuffer will let you know
+// if the filter is invalid.
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum Filter {
+    // Logical group: ["And", [filters...]] or ["Or", [filters...]]
+    Logical(LogicalFilter),
+
+    // Negation: ["Not", filter]
+    Not(NotFilter),
+
+    // Atomic comparison: ["field", "op", value]
+    Comparison(ComparisonFilter),
+}
+
+/// Represents a logical group like ["And", [...]] or ["Or", [...]]
+#[derive(Debug, Serialize, Deserialize)]
+pub struct LogicalFilter(
+    pub String,      // "And" or "Or"
+    pub Vec<Filter>, // nested filters
+);
+
+/// Represents a unary negation: ["Not", inner_filter]
+#[derive(Debug, Serialize, Deserialize)]
+pub struct NotFilter(
+    pub String,      // must be "Not"
+    pub Box<Filter>, // inner filter
+);
+
+/// Represents a basic comparison: ["field", "op", value]
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ComparisonFilter(
+    pub String,       // field
+    pub ComparisonOp, // operator
+    pub Value,        // right-hand side (string, number, or array)
+);
+
+/// Supported comparison operators
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub enum ComparisonOp {
+    Eq,
+    Neq,
+    In,
+    NotIn,
+    Lt,
+    Lte,
+    Gt,
+    Gte,
+    Glob,
+    NotGlob,
+}


### PR DESCRIPTION
Adds two new functions to the examples, specifically with data modeled for the upcoming BuffConf workshop. Added some specific docstrings to showcase setup and example queries with `curl` + `jq`. However, any kind of client can perform an HTTP POST on their Momento function.

## Demo

### Indexing

1. Run `cargo build --examples --release` to generate the wasm
2. Create cache: `momento cache create --name my-functions-cache`
3. Create function:
```bash
export MOMENTO_CELL_HOSTNAME=<momento cell>
export MOMENTO_CACHE_NAME=my-functions-cache
export MOMENTO_API_KEY=<api-key>

export OPENAI_KEY=<openai api key>
export TURBOPUFFER_ENDPOINT=<Should be v2 namespace>
export TURBOPUFFER_API_KEY=<turbopuffer api key>

momento preview function put-function \
  --cache-name "$MOMENTO_CACHE_NAME" \
  --name turbopuffer-index-articles \
  --wasm-file target/wasm32-wasip2/release/examples/turbopuffer_index_articles.wasm \
  -E OPENAI_KEY="$OPENAI_KEY" \
  -E TURBOPUFFER_ENDPOINT="$TURBOPUFFER_ENDPOINT" \
  -E TURBOPUFFER_API_KEY="$TURBOPUFFER_API_KEY"
```
4. In a separate terminal, subscribe to function's logs:
```bash
momento topic subscribe --cache "$MOMENTO_CACHE_NAME" turbopuffer-index-articles
```
5. For speed, upload some NBA-related articles from CBS:
```bash
Tylers-MacBook-Pro :: data/content/normalized » jq '.articles.nba' cbssports-articles-2025-07-11-12-16-05.json | curl https://api.cache.$MOMENTO_CELL_HOSTNAME/functions/my-functions-cache/turbopuffer-index-articles \
-H "authorization: $MOMENTO_API_KEY" \
-H "Content-Type: application/json" \
-H "x-momento-log: debug" \
pipe> -d @-
{"message":"Documents indexed successfully"}%
Tylers-MacBook-Pro :: data/content/normalized »
```
6. We can see that this processed via a sample of debug logs:
```
"DEBUG turbopuffer_index_articles momento-functions/examples/turbopuffer-index-articles.rs:221 setting embeddings in cache"
"DEBUG turbopuffer_index_articles momento-functions/examples/turbopuffer-index-articles.rs:131 getting embedding for id 15278573909111598530"
"DEBUG turbopuffer_index_articles momento-functions/examples/turbopuffer-index-articles.rs:194 Checking if embeddings are already cached for input"
"DEBUG turbopuffer_index_articles momento-functions/examples/turbopuffer-index-articles.rs:208 cache miss, querying embeddings from open ai"
"DEBUG turbopuffer_index_articles momento-functions/examples/turbopuffer-index-articles.rs:239 getting embeddings for input"
"DEBUG turbopuffer_index_articles momento-functions/examples/turbopuffer-index-articles.rs:270 OpenAI response: [(\"date\", \"Tue, 15 Jul 2025 16:01:24 GMT\"), (\"content-type\", \"application/json\"), (\"content-length\", \"33306\"), (\"access-control-allow-origin\", \"*\"), (\"access-control-expose-headers\", \"X-Request-ID\"), (\"openai-model\", \"text-embedding-3-small\"), (\"openai-organization\", \"momento-ywmt8c\"), (\"openai-processing-ms\", \"238\"), (\"openai-version\", \"2020-10-01\"), (\"strict-transport-security\", \"max-age=31536000; includeSubDomains; preload\"), (\"via\", \"envoy-router-bd9f6895d-kthj6\"), (\"x-envoy-upstream-service-time\", \"286\"), (\"x-ratelimit-limit-requests\", \"3000\"), (\"x-ratelimit-limit-tokens\", \"1000000\"), (\"x-ratelimit-remaining-requests\", \"2999\"), (\"x-ratelimit-remaining-tokens\", \"999138\"), (\"x-ratelimit-reset-requests\", \"20ms\"), (\"x-ratelimit-reset-tokens\", \"51ms\"), (\"x-request-id\", \"req_b8d2132af789fe315deb19c71a625979\"), (\"cf-cache-status\", \"DYNAMIC\"), (\"set-cookie\", \"__cf_bm=eR5ck2gK.jdvLQWSWtI5GlQRZwYgdRAD6fGA_2kfg1Y-1752595284-1.0.1.1-Q_ZNVZSneJfLI9gTaXGMrHs8aeW6Rr3eTA4ueeeX5qdSeIGSbuAlZUvRT_4yXKKFHe7PLMnOq0K_k2m_x4iQf5XBEOuBIg80WM0mZdOF7sw; path=/; expires=Tue, 15-Jul-25 16:31:24 GMT; domain=.api.openai.com; HttpOnly; Secure\"), (\"\", \"_cfuvid=tRoGuT8vnHykJvQBUqFHTbVRgswDArvw4JOBx4PsEkM-1752595284941-0.0.1.1-604800000; path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None\"), (\"x-content-type-options\", \"nosniff\"), (\"server\", \"cloudflare\"), (\"cf-ray\", \"95fa7a706838e5c0-PDX\"), (\"alt-svc\", \"h3=\\\":443\\\"; ma=86400\")]"
"DEBUG turbopuffer_index_articles momento-functions/examples/turbopuffer-index-articles.rs:221 setting embeddings in cache"
```

### Searching

1. Run `cargo build --examples --release` to generate the wasm
2. Create cache: `momento cache create --name my-functions-cache`
3. Create function:
```bash
export MOMENTO_CELL_HOSTNAME=<momento cell>
export MOMENTO_CACHE_NAME=my-functions-cache
export MOMENTO_API_KEY=<api-key>

export OPENAI_KEY=<openai api key>
export TURBOPUFFER_ENDPOINT=<Should be v2 namespace>
export TURBOPUFFER_API_KEY=<turbopuffer api key>

momento preview function put-function \
  --cache-name "$MOMENTO_CACHE_NAME" \
  --name turbopuffer-search-articles \
  --wasm-file target/wasm32-wasip2/release/examples/turbopuffer_search_articles.wasm \
  -E OPENAI_KEY="$OPENAI_KEY" \
  -E TURBOPUFFER_ENDPOINT="$TURBOPUFFER_ENDPOINT" \
  -E TURBOPUFFER_API_KEY="$TURBOPUFFER_API_KEY"
```
4. In a separate terminal, subscribe to function's logs:
```bash
momento topic subscribe --cache "$MOMENTO_CACHE_NAME" turbopuffer-search-articles
```
5. Perform a basic search:
```
Tylers-MacBook-Pro :: ~/repo/functions ‹feat/turbopuffer-workshop› » curl --silent \
 https://api.cache.$MOMENTO_CELL_HOSTNAME/functions/$MOMENTO_CACHE_NAME/turbopuffer-search-articles \
  -H "authorization: $MOMENTO_API_KEY" \
  -H "Content-Type: application/json" \
  -d '{"topk": 5, "query": "Portland Trail Blazers", "include_attributes": ["metadata$title", "metadata$link"]}'  | jq
[
  {
    "dist": 0.5403858,
    "id": "13438091020403724554",
    "metadata$title": "NBA trade rumors: Celtics exploring options for recent acquisition Anfernee Simons in cost-cutting move",
    "metadata$link": "https://www.cbssports.com/nba/news/nba-trade-rumors-celtics-exploring-options-for-recent-acquisition-anfernee-simons-in-cost-cutting-move/"
  },
  {
    "dist": 0.5705922,
    "id": "7284858655268854146",
    "metadata$title": "Norman Powell explains why Miami Heat trade fulfills 'childhood dream,' details Dwyane Wade fandom",
    "metadata$link": "https://www.cbssports.com/nba/news/norman-powell-explains-why-miami-heat-trade-fulfills-childhood-dream-details-dwyane-wade-fandom/"
  },
  {
    "dist": 0.5740936,
    "id": "2406550701978436303",
    "metadata$title": "Why Damian Lillard is big winner after Bucks release; Fever claim Commissioner's Cup without Caitlin Clark",
    "metadata$link": "https://www.cbssports.com/nba/news/why-damian-lillard-is-big-winner-after-bucks-release-fever-claim-commissioners-cup-without-caitlin-clark/"
  },
  {
    "dist": 0.5753931,
    "id": "11782925380870169755",
    "metadata$title": "Former Trail Blazers guard Ben McLemore receives prison sentence following rape conviction",
    "metadata$link": "https://www.cbssports.com/nba/news/former-trail-blazers-guard-ben-mclemore-receives-prison-sentence-following-rape-conviction/"
  },
  {
    "dist": 0.5785141,
    "id": "15730368927505366783",
    "metadata$title": "NBA offseason grades for every West team: Rockets ace summer, Lakers and Mavericks fall short, one team fails",
    "metadata$link": "https://www.cbssports.com/nba/news/nba-offseason-grades-for-every-west-team-rockets-ace-summer-lakers-and-mavericks-fall-short-one-team-fails/"
  }
]
Tylers-MacBook-Pro :: ~/repo/functions ‹feat/turbopuffer-workshop› »
```
6. Perform a more advanced search, filtering out specific articles + using `jq` to further filter the distance:
```
Tylers-MacBook-Pro :: ~/repo/functions ‹feat/turbopuffer-workshop› » read -r -d '' payload << EOM
{
 "topk": 25,
 "query": "Portland Trail Blazers",
 "include_attributes": [
   "metadata\$title",
   "metadata\$link"
 ],
 "filters": [
   "And",
   [
     ["metadata\$title", "NotGlob", "*Mock Draft*"],
     ["Not", ["id", "In", ["11782925380870169755"]]]
   ]
 ]
}
EOM
curl --silent \
 https://api.cache.$MOMENTO_CELL_HOSTNAME/functions/$MOMENTO_CACHE_NAME/turbopuffer-search-articles \
 -H "authorization: $MOMENTO_API_KEY" \
 -H "Content-Type: application/json" \
 -d "$payload" | \
jq '[.[] | select(.dist <= 0.6)]'
[
  {
    "dist": 0.54046816,
    "id": "13438091020403724554",
    "metadata$title": "NBA trade rumors: Celtics exploring options for recent acquisition Anfernee Simons in cost-cutting move",
    "metadata$link": "https://www.cbssports.com/nba/news/nba-trade-rumors-celtics-exploring-options-for-recent-acquisition-anfernee-simons-in-cost-cutting-move/"
  },
  {
    "dist": 0.5705662,
    "id": "7284858655268854146",
    "metadata$title": "Norman Powell explains why Miami Heat trade fulfills 'childhood dream,' details Dwyane Wade fandom",
    "metadata$link": "https://www.cbssports.com/nba/news/norman-powell-explains-why-miami-heat-trade-fulfills-childhood-dream-details-dwyane-wade-fandom/"
  },
  {
    "dist": 0.57406735,
    "id": "2406550701978436303",
    "metadata$title": "Why Damian Lillard is big winner after Bucks release; Fever claim Commissioner's Cup without Caitlin Clark",
    "metadata$link": "https://www.cbssports.com/nba/news/why-damian-lillard-is-big-winner-after-bucks-release-fever-claim-commissioners-cup-without-caitlin-clark/"
  },
  {
    "dist": 0.5786102,
    "id": "15730368927505366783",
    "metadata$title": "NBA offseason grades for every West team: Rockets ace summer, Lakers and Mavericks fall short, one team fails",
    "metadata$link": "https://www.cbssports.com/nba/news/nba-offseason-grades-for-every-west-team-rockets-ace-summer-lakers-and-mavericks-fall-short-one-team-fails/"
  },
  {
    "dist": 0.58598816,
    "id": "2939085035640608871",
    "metadata$title": "NBA summer league rosters: Full list for Lakers, Knicks, Warriors, more with lots of familiar names in Vegas",
    "metadata$link": "https://www.cbssports.com/nba/news/nba-summer-league-rosters-full-list-for-lakers-knicks-warriors-more-with-lots-of-familiar-names-in-vegas/"
  },
  {
    "dist": 0.5898422,
    "id": "17304388502754185354",
    "metadata$title": "NBA Las Vegas Summer League schedule: Where to watch, TV channel, live stream, dates, game times",
    "metadata$link": "https://www.cbssports.com/nba/news/nba-las-vegas-summer-league-schedule-where-to-watch-tv-channel-live-stream-dates-game-times/"
  },
  {
    "dist": 0.5950302,
    "id": "13332115135093349454",
    "metadata$title": "2025 NBA free agency tracker: Latest moves, player rankings as Lakers sign Deandre Ayton",
    "metadata$link": "https://www.cbssports.com/nba/news/2025-nba-free-agency-tracker-latest-moves-player-rankings-as-lakers-sign-deandre-ayton/"
  },
  {
    "dist": 0.59793025,
    "id": "1820032552031866777",
    "metadata$title": "Michael Porter Jr. breaks silence on Nets trade: Nuggets departure offers chance to 'expand' game",
    "metadata$link": "https://www.cbssports.com/nba/news/michael-porter-jr-breaks-silence-on-nets-trade-nuggets-departure-offers-chance-to-expand-game/"
  },
  {
    "dist": 0.5981035,
    "id": "7314049544933645656",
    "metadata$title": "Today's top games to watch, best bets, odds: NHL Stanley Cup Final, MLB, WNBA and more",
    "metadata$link": "https://www.cbssports.com/betting/news/todays-top-games-to-watch-best-bets-odds-nhl-stanley-cup-final-mlb-wnba-and-more/"
  },
  {
    "dist": 0.5989287,
    "id": "8987233423512080428",
    "metadata$title": "Nuggets' Cameron Johnson, Tim Hardaway Jr. explain why they're excited to play with Nikola Jokić",
    "metadata$link": "https://www.cbssports.com/nba/news/nuggets-cameron-johnson-tim-hardaway-jr-explain-why-theyre-excited-to-play-with-nikola-jokic/"
  },
  {
    "dist": 0.59900725,
    "id": "3933789551135929664",
    "metadata$title": "NBA offseason grades for every East team: One team aces summer, Celtics, Knicks in 'B' tier, Bulls confuse",
    "metadata$link": "https://www.cbssports.com/nba/news/nba-offseason-grades-for-every-east-team-one-team-aces-summer-celtics-knicks-in-b-tier-bulls-confuse/"
  }
]
Tylers-MacBook-Pro :: ~/repo/functions ‹feat/turbopuffer-workshop› »
```
