### PR TITLE
fix: don't explictly include id as an attribute for turbopuffer queries, as this is already provided

### DIFF
--- a/momento-functions/examples/turbopuffer-recommend-articles.rs
+++ b/momento-functions/examples/turbopuffer-recommend-articles.rs
@@ -363,7 +363,7 @@ fn get_similar_articles_from_turbopuffer(
         json!({
             "rank_by": ["vector", "ANN", mean_vector],
             "top_k": topk,
-            "include_attributes": vec!["id", "metadata$title", "metadata$link"],
+            "include_attributes": vec!["metadata$title", "metadata$link"],
             "filters": Filter::Comparison(
                 ComparisonFilter("id".to_string(),
                 ComparisonOp::NotIn,


### PR DESCRIPTION
Fun little bug to knock out. As of this PR, if you add an attribute in the `include_attributes` param for Turbopuffer (and it's included by default), it will duplicate that attribute and send invalid Json back
