### PR TITLE
feat: port Token Vending Machine to functions. defines and binds new WIT interfaces/types.

### DIFF
--- a/momento-functions-host/src/lib.rs
+++ b/momento-functions-host/src/lib.rs
@@ -18,6 +18,7 @@ pub mod encoding;
 pub mod http;
 pub mod redis;
 mod spawn;
+pub mod token;
 pub mod topics;
 pub mod web_extensions;
 

--- a/momento-functions-host/src/token.rs
+++ b/momento-functions-host/src/token.rs
@@ -1,0 +1,386 @@
+//! Host interface for working with Momento Token apis
+use momento_functions_wit::host::momento::functions::permission_messages;
+use momento_functions_wit::host::momento::functions::token;
+use momento_functions_wit::host::momento::functions::token::Expires;
+
+/// An error occurred when generating a disposable token
+#[derive(thiserror::Error, Debug)]
+pub enum GenerateDisposableTokenError {
+    /// An error occurred when calling the host generate function
+    #[error(transparent)]
+    TokenError(#[from] token::TokenError),
+}
+
+/// Generate a disposable token with specific permissions.
+pub fn generate_disposable_token(
+    valid_for_seconds: u32,
+    permissions: PermissionsBuilder,
+    token_id: Option<String>,
+) -> Result<FunctionHostGenerateDisposableTokenResponse, GenerateDisposableTokenError> {
+    let permissions: momento_functions_wit::host::momento::functions::permission_messages::Permissions = permissions.into();
+    token::generate_disposable_token(
+        Expires { valid_for_seconds },
+        &permissions,
+        token_id.as_deref(),
+    )
+    .map_err(Into::into)
+    .map(Into::into)
+}
+
+/// The translated response from the .WIT interface to a Rust-native one
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FunctionHostGenerateDisposableTokenResponse {
+    /// The new, disposable token with scoped permissions
+    pub api_key: String,
+    /// The endpoint to be used against when calling Momento with this token
+    pub endpoint: String,
+    /// How long the token is valid for, in epoch seconds
+    pub valid_until: u64,
+}
+
+impl From<momento_functions_wit::host::momento::functions::token::GenerateDisposableTokenResponse>
+    for FunctionHostGenerateDisposableTokenResponse
+{
+    fn from(
+        response: momento_functions_wit::host::momento::functions::token::GenerateDisposableTokenResponse,
+    ) -> Self {
+        FunctionHostGenerateDisposableTokenResponse {
+            api_key: response.api_key,
+            endpoint: response.endpoint,
+            valid_until: response.valid_until,
+        }
+    }
+}
+
+/// Builds a single instance of restricted Cache permissions
+#[derive(Clone, Debug)]
+pub struct CachePermissionsBuilder {
+    role: permission_messages::CacheRole,
+    cache: permission_messages::CachePermissionsCache,
+    cache_item: permission_messages::CachePermissionsItem,
+}
+
+impl Default for CachePermissionsBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl CachePermissionsBuilder {
+    /// Instantiates the builder with default values that will not allow
+    /// any access to any caches nor the items within them.
+    pub fn new() -> Self {
+        Self {
+            role: permission_messages::CacheRole::CachePermitNone,
+            cache: permission_messages::CachePermissionsCache::AllCaches,
+            cache_item: permission_messages::CachePermissionsItem::AllItems,
+        }
+    }
+
+    /// Explicitly permits no caches in the role
+    pub fn none(mut self) -> Self {
+        self.role = permission_messages::CacheRole::CachePermitNone;
+        self
+    }
+    /// Explicitly permits read/write access for caches in the role
+    pub fn read_write(mut self) -> Self {
+        self.role = permission_messages::CacheRole::CacheReadWrite;
+        self
+    }
+    /// Explicitly permits read-only access for caches in the role
+    pub fn read_only(mut self) -> Self {
+        self.role = permission_messages::CacheRole::CacheReadOnly;
+        self
+    }
+    /// Explicitly permits write-only access for caches in the role
+    pub fn write_only(mut self) -> Self {
+        self.role = permission_messages::CacheRole::CacheWriteOnly;
+        self
+    }
+
+    /// Explicitly permits all caches can be accessed
+    pub fn all_caches(mut self) -> Self {
+        self.cache = permission_messages::CachePermissionsCache::AllCaches;
+        self
+    }
+    /// Explicitly permits only a specific Cache
+    pub fn cache_name(mut self, name: impl Into<String>) -> Self {
+        self.cache = permission_messages::CachePermissionsCache::CacheSelector(
+            permission_messages::CacheSelector::CacheName(name.into()),
+        );
+        self
+    }
+
+    /// Explicitly permits all items within the specified cache(s)
+    pub fn all_items(mut self) -> Self {
+        self.cache_item = permission_messages::CachePermissionsItem::AllItems;
+        self
+    }
+    /// Explicitly permits access to this specific key within the cache
+    pub fn item_key(mut self, key: Vec<u8>) -> Self {
+        self.cache_item = permission_messages::CachePermissionsItem::ItemSelector(
+            permission_messages::CacheItemSelector::Key(key),
+        );
+        self
+    }
+    /// Explicitly permits access to keys that begin with this prefix
+    pub fn item_key_prefix(mut self, prefix: Vec<u8>) -> Self {
+        self.cache_item = permission_messages::CachePermissionsItem::ItemSelector(
+            permission_messages::CacheItemSelector::KeyPrefix(prefix),
+        );
+        self
+    }
+
+    /// Finalize into the generated WIT type
+    pub fn build(self) -> permission_messages::CachePermissions {
+        permission_messages::CachePermissions {
+            role: self.role,
+            cache: self.cache,
+            cache_item: self.cache_item,
+        }
+    }
+}
+
+/// Builds a single instance of restricted Topic permissions
+#[derive(Clone, Debug)]
+pub struct TopicPermissionsBuilder {
+    role: permission_messages::TopicRole,
+    cache: permission_messages::TopicPermissionsCache,
+    topic: permission_messages::TopicPermissionsTopic,
+}
+
+impl Default for TopicPermissionsBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl TopicPermissionsBuilder {
+    /// Instantiates the builder with default values that will not allow
+    /// any access to any topics belonging to any caches
+    pub fn new() -> Self {
+        Self {
+            role: permission_messages::TopicRole::TopicPermitNone,
+            cache: permission_messages::TopicPermissionsCache::AllCaches,
+            topic: permission_messages::TopicPermissionsTopic::AllTopics,
+        }
+    }
+
+    /// Explicitly permits no topics in the role
+    pub fn none(mut self) -> Self {
+        self.role = permission_messages::TopicRole::TopicPermitNone;
+        self
+    }
+    /// Explicitly permits publish/subscribe access to topics in the role
+    pub fn read_write(mut self) -> Self {
+        self.role = permission_messages::TopicRole::TopicReadWrite;
+        self
+    }
+    /// Explicitly permits subscribe access to topics in the role
+    pub fn read_only(mut self) -> Self {
+        self.role = permission_messages::TopicRole::TopicReadOnly;
+        self
+    }
+    /// Explicitly permits publish access to topics in the role
+    pub fn write_only(mut self) -> Self {
+        self.role = permission_messages::TopicRole::TopicWriteOnly;
+        self
+    }
+
+    /// Explicitly permits topics access to all caches
+    pub fn all_caches(mut self) -> Self {
+        self.cache = permission_messages::TopicPermissionsCache::AllCaches;
+        self
+    }
+    /// Explicitly permits topics access to a specific cache
+    pub fn cache_name(mut self, name: impl Into<String>) -> Self {
+        self.cache = permission_messages::TopicPermissionsCache::CacheSelector(
+            permission_messages::CacheSelector::CacheName(name.into()),
+        );
+        self
+    }
+
+    /// Explicitly permits topics access to all topics
+    pub fn all_topics(mut self) -> Self {
+        self.topic = permission_messages::TopicPermissionsTopic::AllTopics;
+        self
+    }
+    /// Explicitly permits topics access to a specific topic
+    pub fn topic_name(mut self, name: impl Into<String>) -> Self {
+        self.topic = permission_messages::TopicPermissionsTopic::TopicSelector(
+            permission_messages::TopicSelector::TopicName(name.into()),
+        );
+        self
+    }
+    /// Explicitly permits topics access to topics beginning with this prefix
+    pub fn topic_name_prefix(mut self, prefix: impl Into<String>) -> Self {
+        self.topic = permission_messages::TopicPermissionsTopic::TopicSelector(
+            permission_messages::TopicSelector::TopicNamePrefix(prefix.into()),
+        );
+        self
+    }
+
+    /// Finalized into the generated WIT type
+    pub fn build(self) -> permission_messages::TopicPermissions {
+        permission_messages::TopicPermissions {
+            role: self.role,
+            cache: self.cache,
+            topic: self.topic,
+        }
+    }
+}
+
+/// Builds a single instance of restricted Function permissions
+#[derive(Clone, Debug)]
+pub struct FunctionPermissionsBuilder {
+    role: permission_messages::FunctionRole,
+    cache: permission_messages::FunctionPermissionsCache,
+    function: permission_messages::FunctionPermissionsFunction,
+}
+
+impl Default for FunctionPermissionsBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl FunctionPermissionsBuilder {
+    /// Instantiates the builder with default values that will not allow
+    /// any access to any functions belonging to any caches
+    pub fn new() -> Self {
+        Self {
+            role: permission_messages::FunctionRole::FunctionPermitNone,
+            cache: permission_messages::FunctionPermissionsCache::AllCaches,
+            function: permission_messages::FunctionPermissionsFunction::AllFunctions,
+        }
+    }
+
+    /// Allow no access to any functions
+    pub fn none(mut self) -> Self {
+        self.role = permission_messages::FunctionRole::FunctionPermitNone;
+        self
+    }
+    /// Allow access to invoke functions
+    pub fn invoke(mut self) -> Self {
+        self.role = permission_messages::FunctionRole::FunctionInvoke;
+        self
+    }
+
+    /// Restricts access to functions within all caches
+    pub fn all_caches(mut self) -> Self {
+        self.cache = permission_messages::FunctionPermissionsCache::AllCaches;
+        self
+    }
+    /// Restricts access to functions within a specifi cache
+    pub fn cache_name(mut self, name: impl Into<String>) -> Self {
+        self.cache = permission_messages::FunctionPermissionsCache::CacheSelector(
+            permission_messages::CacheSelector::CacheName(name.into()),
+        );
+        self
+    }
+
+    /// Restricts access to all functions
+    pub fn all_functions(mut self) -> Self {
+        self.function = permission_messages::FunctionPermissionsFunction::AllFunctions;
+        self
+    }
+    /// Restricts access to a specific function
+    pub fn function_name(mut self, name: impl Into<String>) -> Self {
+        self.function = permission_messages::FunctionPermissionsFunction::FunctionSelector(
+            permission_messages::FunctionSelector::FunctionName(name.into()),
+        );
+        self
+    }
+    /// Restricts access to functions beginning with this prefix
+    pub fn function_name_prefix(mut self, prefix: impl Into<String>) -> Self {
+        self.function = permission_messages::FunctionPermissionsFunction::FunctionSelector(
+            permission_messages::FunctionSelector::FunctionNamePrefix(prefix.into()),
+        );
+        self
+    }
+
+    /// Finalized into the generated WIT type
+    pub fn build(self) -> permission_messages::FunctionPermissions {
+        permission_messages::FunctionPermissions {
+            role: self.role,
+            cache: self.cache,
+            function: self.function,
+        }
+    }
+}
+
+/// Top-level builder for building the desired permissions of your scoped token
+#[derive(Clone, Debug)]
+pub struct PermissionsBuilder {
+    superuser: bool,
+    explicit_permissions: Vec<permission_messages::PermissionsType>,
+}
+
+impl Default for PermissionsBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl PermissionsBuilder {
+    /// Creates a default Permissions builder that isn't a superuser and has no permissions
+    pub fn new() -> Self {
+        Self {
+            superuser: false,
+            explicit_permissions: Vec::new(),
+        }
+    }
+
+    /// Grant superuser permissions (ignores explicit permissions).
+    /// ***Only a superuser can grant superuser permissions***.
+    pub fn super_user(mut self) -> Self {
+        self.superuser = true;
+        self
+    }
+
+    /// Add an explicit cache permission
+    pub fn add_cache(mut self, cache_perms: CachePermissionsBuilder) -> Self {
+        self.explicit_permissions
+            .push(permission_messages::PermissionsType::CachePermissions(
+                cache_perms.build(),
+            ));
+        self
+    }
+
+    /// Add an explicit topic permission
+    pub fn add_topic(mut self, topic_perms: TopicPermissionsBuilder) -> Self {
+        self.explicit_permissions
+            .push(permission_messages::PermissionsType::TopicPermissions(
+                topic_perms.build(),
+            ));
+        self
+    }
+
+    /// Add an explicit function permission
+    pub fn add_function(mut self, func_perms: FunctionPermissionsBuilder) -> Self {
+        self.explicit_permissions
+            .push(permission_messages::PermissionsType::FunctionPermissions(
+                func_perms.build(),
+            ));
+        self
+    }
+
+    /// Finalize into the generated WIT Permissions
+    pub fn build(self) -> permission_messages::Permissions {
+        if self.superuser {
+            permission_messages::Permissions::SuperUser(
+                permission_messages::SuperUserPermissions::SuperUser,
+            )
+        } else {
+            permission_messages::Permissions::Explicit(permission_messages::ExplicitPermissions {
+                permissions: self.explicit_permissions,
+            })
+        }
+    }
+}
+
+impl From<PermissionsBuilder> for permission_messages::Permissions {
+    fn from(pb: PermissionsBuilder) -> Self {
+        pb.build()
+    }
+}

--- a/momento-functions-wit/wit/permission-messages.wit
+++ b/momento-functions-wit/wit/permission-messages.wit
@@ -1,0 +1,116 @@
+interface permission-messages {
+  // Aliases for categories of functionality.
+  enum cache-role {
+    cache-permit-none,
+    // Restricts access to apis that read and write data from caches
+    cache-read-write,
+    // Restricts access to apis that read from caches
+    cache-read-only,
+    // Restricts access to apis that write from caches
+    // Doesn't allow conditional write APIs (SetIfNotExists, IncreaseTTL etc)
+    cache-write-only,
+  }
+
+  // Aliases for categories of functionality.
+  enum topic-role {
+    topic-permit-none,
+    // Restricts access to apis that read and write data from topics
+    topic-read-write,
+    // Restricts access to apis that read from topics
+    topic-read-only,
+    // Restricts access to apis that write from topics
+    topic-write-only,
+  }
+
+  // Aliases for categories of functionality.
+  enum function-role {
+    function-permit-none,
+    function-invoke,
+  }
+
+  enum super-user-permissions {
+    super-user,
+  }
+
+  variant permissions {
+    super-user(super-user-permissions),
+    explicit(explicit-permissions),
+  }
+
+  record explicit-permissions {
+    permissions: list<permissions-type>,
+  }
+
+  variant cache-selector {
+    cache-name(string),
+  }
+
+  variant cache-item-selector {
+    key(list<u8>),
+    key-prefix(list<u8>),
+  }
+
+  variant cache-permissions-cache {
+    all-caches,
+    cache-selector(cache-selector),
+  }
+
+  variant cache-permissions-item {
+    all-items,
+    item-selector(cache-item-selector),
+  }
+
+  record cache-permissions {
+    role: cache-role,
+    cache: cache-permissions-cache,
+    cache-item: cache-permissions-item,
+  }
+
+  variant topic-selector {
+    topic-name(string),
+    topic-name-prefix(string),
+  }
+
+  variant topic-permissions-cache {
+    all-caches,
+    cache-selector(cache-selector),
+  }
+
+  variant topic-permissions-topic {
+    all-topics,
+    topic-selector(topic-selector),
+  }
+
+  record topic-permissions {
+    role: topic-role,
+    cache: topic-permissions-cache,
+    topic: topic-permissions-topic,
+  }
+
+  variant function-selector {
+    function-name(string),
+    function-name-prefix(string),
+  }
+
+  variant function-permissions-cache {
+    all-caches,
+    cache-selector(cache-selector),
+  }
+
+  variant function-permissions-function {
+    all-functions,
+    function-selector(function-selector),
+  }
+
+  record function-permissions {
+    role: function-role,
+    cache: function-permissions-cache,
+    function: function-permissions-function,
+  }
+
+  variant permissions-type {
+    cache-permissions(cache-permissions),
+    topic-permissions(topic-permissions),
+    function-permissions(function-permissions),
+  }
+}

--- a/momento-functions-wit/wit/token.wit
+++ b/momento-functions-wit/wit/token.wit
@@ -1,0 +1,36 @@
+interface token {
+  use permission-messages.{permissions};
+
+  /// An error occurred while making the call.
+   variant token-error {
+        internal-error,
+        invalid-argument(string),
+        permission-denied(string),
+        limit-exceeded(string),
+    }
+
+  record expires {
+    /// How many seconds would you like the token to be valid for?
+    valid-for-seconds: u32,
+  }
+
+  record generate-disposable-token-response {
+    /// The new token
+    api-key: string,
+    /// The endpoint this token can be used again
+    endpoint: string,
+    /// Epoch seconds when the token expires
+    valid-until: u64,
+  }
+
+  /// Generate a token that has an expiry
+  generate-disposable-token: func(
+     /// Sets when the token will expire
+    expires: expires,
+    /// The permissions for the new token to be scoped with.
+    permissions: permissions,
+    /// Optional string to be included inside the token. This field can also
+    /// be used to include a payload you know is signed within the token.
+    token-id: option<string>,
+  ) -> result<generate-disposable-token-response, token-error>;
+}

--- a/momento-functions-wit/wit/world.wit
+++ b/momento-functions-wit/wit/world.wit
@@ -4,6 +4,8 @@ world host {
     include momento:host/imports@1.0.0;
 
     import cache-scalar;
+    import permission-messages;
+    import token;
     import topic;
 }
 

--- a/momento-functions/Cargo.toml
+++ b/momento-functions/Cargo.toml
@@ -31,6 +31,10 @@ name = "fine-foods-embeddings"
 crate-type = ["cdylib"]
 
 [[example]]
+name = "token-vending-machine"
+crate-type = ["cdylib"]
+
+[[example]]
 name = "turbopuffer-index"
 crate-type = ["cdylib"]
 

--- a/momento-functions/examples/token-vending-machine.rs
+++ b/momento-functions/examples/token-vending-machine.rs
@@ -1,0 +1,108 @@
+//! This example showcases how you can create a simple function that vends temporary, scoped permissions
+//! without having to create something like a Lambda-backed API Gateway solution combined with some DNS route. However, this function
+//! is still protected by auth required in order to invoke the function.
+//!
+//! You can modify this code as necessary for your needs, but this example will generate a scoped token that expires in 1 hour
+//! that has the following permissions:
+//! * Cache
+//!     * Read/Write
+//!     * All items within the cache
+//!     * Only cache `foo`
+//! * Topic
+//!     * Read (subscribe)
+//!     * Only cache `foo`
+//!     * Topics beginning with prefix `notification-`
+//!
+//! You may also notice we are passing in a value for `token_id`. `token_id` is a bit of a
+//! misnomer in the Momento protos, but consider it like a "secret value" you can pass through
+//! to the generated JWT that you know is verified since is signed by Momento. It could be a
+//! stringified JWT of your own service, a simple string, a nonce, you name it.
+//!
+//! For this example, we'll simply call it `"my very secret value"`.
+use std::time::Duration;
+
+use log::LevelFilter;
+use momento_functions::{WebResponse, WebResult};
+use momento_functions_host::{
+    encoding::Json,
+    token::{self, CachePermissionsBuilder, PermissionsBuilder, TopicPermissionsBuilder},
+};
+use momento_functions_log::LogMode;
+use serde_json::json;
+
+#[derive(serde::Serialize)]
+struct Response {
+    api_key: String,
+    endpoint: String,
+    valid_until: u64,
+}
+
+momento_functions::post!(greet);
+fn greet(_payload: Vec<u8>) -> WebResult<WebResponse> {
+    momento_functions_log::configure_logging(
+        LevelFilter::Info,
+        LogMode::Topic {
+            topic: "token-vending-machine".to_string(),
+        },
+    )?;
+
+    log::debug!("received request to generate a disposable token");
+
+    // Example permissions builder that makes constructing permissions straightforward.
+    // You can add multiple of the same kind of permissions (cache, topic, functions, etc),
+    // and validation will be performed by Momento when the request is passed through.
+    let permissions = PermissionsBuilder::new()
+        .add_cache(
+            CachePermissionsBuilder::new()
+                .read_write()
+                .cache_name("foo")
+                .all_items(),
+        )
+        .add_topic(
+            TopicPermissionsBuilder::new()
+                .read_only()
+                .cache_name("foo")
+                .topic_name_prefix("notification-"),
+        );
+    // As documented above, consider this a secret value you want securely embedded and
+    // signed in your generated JWT.
+    let token_id = Some("my very secret value".to_string());
+
+    match token::generate_disposable_token(
+        Duration::from_hours(1).as_secs() as u32,
+        permissions,
+        token_id,
+    ) {
+        Ok(result) => {
+            // For now we just convert the response into something we can serialize,
+            // but if you want to inspect the result you may do so here.
+            let body = Json(Response {
+                api_key: result.api_key,
+                endpoint: result.endpoint,
+                valid_until: result.valid_until,
+            });
+            Ok(WebResponse::new()
+                .with_status(200)
+                .with_headers(vec![(
+                    "Content-Type".to_string(),
+                    "application/json".to_string(),
+                )])
+                .with_body(body)?)
+        }
+        Err(e) => {
+            // Capture logging so we can help debug why requests are failing
+            log::error!("Failed to generate token: {e:?}");
+            let status = match &e {
+                token::GenerateDisposableTokenError::TokenError(token_error) => match token_error {
+                    momento_functions_wit::host::momento::functions::token::TokenError::InvalidArgument(_) => 400,
+                    momento_functions_wit::host::momento::functions::token::TokenError::PermissionDenied(_) => 403,
+                    momento_functions_wit::host::momento::functions::token::TokenError::LimitExceeded(_) => 429,
+                    momento_functions_wit::host::momento::functions::token::TokenError::InternalError => 500,
+                },
+            };
+            Ok(WebResponse::new().with_status(status).with_body(json!({
+                "message": e.to_string(),
+            }))?)
+        }
+    }
+}


### PR DESCRIPTION
Momento currently has examples on how to make a token vending machine for temporary, scoped Momento tokens. But those examples are typically based around some form of a cloud deployment, such as AWS using API Gateway backed by a Lambda function and aren't protected by auth.

This PR ports over the functionality for vending temporary tokens using Momento Functions instead. This gives you a powerful, fast way to generate specific tokens for your customers without having to manage CloudFormation stacks, racking up AWS bills, etc. as well as having the confidence in knowing your function's endpoint is secure.
