### PR TITLE
chore: derive clone on http response

### DIFF
--- a/momento-functions-host/src/http.rs
+++ b/momento-functions-host/src/http.rs
@@ -9,7 +9,7 @@ use crate::{
     encoding::{Encode, Extract},
 };
 
-/// HTTP Get response
+/// HTTP response
 #[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
 pub struct Response {
     /// HTTP status code


### PR DESCRIPTION
For developer convenience, adds a `#[derive(Clone)]` on
`momento_host_functions::http::Response`.
