### PR TITLE
feat: add support for cache list_push and list_pop operations

### DIFF
--- a/momento-functions-host/src/cache.rs
+++ b/momento-functions-host/src/cache.rs
@@ -3,6 +3,7 @@
 use std::time::Duration;
 
 use crate::encoding::{Encode, EncodeError, Extract, ExtractError};
+use momento_functions_wit::host::momento::functions::cache_list;
 use momento_functions_wit::host::momento::functions::cache_scalar;
 
 /// An error occurred when setting a value in the cache.
@@ -31,6 +32,34 @@ pub enum CacheGetError<E: ExtractError> {
     /// An error occurred when calling the host cache function.
     #[error(transparent)]
     CacheError(#[from] cache_scalar::Error),
+}
+
+/// An error occurred when pushing a value to a list in the cache.
+#[derive(thiserror::Error, Debug)]
+pub enum CacheListPushError<E: EncodeError> {
+    /// The provided value could not be encoded.
+    #[error("Failed to encode value.")]
+    EncodeFailed {
+        /// The underlying encoding error.
+        cause: E,
+    },
+    /// An error occurred when calling the host cache function.
+    #[error(transparent)]
+    CacheError(#[from] cache_list::Error),
+}
+
+/// An error occurred when popping a value from a list in the cache.
+#[derive(thiserror::Error, Debug)]
+pub enum CacheListPopError<E: ExtractError> {
+    /// The value could not be extracted with the provided implementation.
+    #[error("Failed to extract value.")]
+    ExtractFailed {
+        /// The underlying error.
+        cause: E,
+    },
+    /// An error occurred when calling the host cache function.
+    #[error(transparent)]
+    CacheError(#[from] cache_list::Error),
 }
 /// Get a value from the cache.
 ///
@@ -127,4 +156,224 @@ pub fn set<E: Encode>(
 
 fn saturate_ttl(ttl: Duration) -> u64 {
     ttl.as_millis().clamp(0, u64::MAX as u128) as u64
+}
+
+/// Push a value to the front of a list in the cache.
+///
+/// Returns the length of the list after the push operation.
+///
+/// Examples:
+/// ________
+/// Bytes:
+/// ```rust
+/// # use momento_functions_host::cache;
+/// # use momento_functions_host::cache::CacheListPushError;
+/// # use std::time::Duration;
+///
+/// # fn f() -> Result<(), CacheListPushError<&'static str>> {
+/// let list_length = cache::list_push_front(
+///     "my_list",
+///     b"hello".to_vec(),
+///     Duration::from_secs(60),
+///     true,
+///     100,
+/// )?;
+/// # Ok(()) }
+/// ```
+/// ________
+/// Json:
+/// ```rust
+/// # use momento_functions_host::cache;
+/// # use momento_functions_host::cache::CacheListPushError;
+/// # use std::time::Duration;
+/// use momento_functions_host::encoding::Json;
+///
+/// #[derive(serde::Serialize)]
+/// struct MyStruct {
+///    hello: String
+/// }
+///
+/// # fn f() -> Result<(), CacheListPushError<Json<MyStruct>>> {
+/// let list_length = cache::list_push_front(
+///     "my_list",
+///     Json(MyStruct { hello: "hello".to_string() }),
+///     Duration::from_secs(60),
+///     true,
+///     100,
+/// )?;
+/// # Ok(()) }
+/// ```
+pub fn list_push_front<E: Encode>(
+    list_name: impl AsRef<[u8]>,
+    value: E,
+    ttl: Duration,
+    refresh_ttl: bool,
+    truncate_back_to_size: u32,
+) -> Result<u32, CacheListPushError<E::Error>> {
+    cache_list::list_push_front(
+        list_name.as_ref(),
+        &value
+            .try_serialize()
+            .map_err(|e| CacheListPushError::EncodeFailed { cause: e })?
+            .into(),
+        saturate_ttl(ttl),
+        refresh_ttl,
+        truncate_back_to_size,
+    )
+    .map_err(Into::into)
+}
+
+/// Push a value to the back of a list in the cache.
+///
+/// Returns the length of the list after the push operation.
+///
+/// Examples:
+/// ________
+/// Bytes:
+/// ```rust
+/// # use momento_functions_host::cache;
+/// # use momento_functions_host::cache::CacheListPushError;
+/// # use std::time::Duration;
+///
+/// # fn f() -> Result<(), CacheListPushError<&'static str>> {
+/// let list_length = cache::list_push_back(
+///     "my_list",
+///     b"hello".to_vec(),
+///     Duration::from_secs(60),
+///     true,
+///     100,
+/// )?;
+/// # Ok(()) }
+/// ```
+/// ________
+/// Json:
+/// ```rust
+/// # use momento_functions_host::cache;
+/// # use momento_functions_host::cache::CacheListPushError;
+/// # use std::time::Duration;
+/// use momento_functions_host::encoding::Json;
+///
+/// #[derive(serde::Serialize)]
+/// struct MyStruct {
+///    hello: String
+/// }
+///
+/// # fn f() -> Result<(), CacheListPushError<Json<MyStruct>>> {
+/// let list_length = cache::list_push_back(
+///     "my_list",
+///     Json(MyStruct { hello: "hello".to_string() }),
+///     Duration::from_secs(60),
+///     true,
+///     100,
+/// )?;
+/// # Ok(()) }
+/// ```
+pub fn list_push_back<E: Encode>(
+    list_name: impl AsRef<[u8]>,
+    value: E,
+    ttl: Duration,
+    refresh_ttl: bool,
+    truncate_back_to_size: u32,
+) -> Result<u32, CacheListPushError<E::Error>> {
+    cache_list::list_push_back(
+        list_name.as_ref(),
+        &value
+            .try_serialize()
+            .map_err(|e| CacheListPushError::EncodeFailed { cause: e })?
+            .into(),
+        saturate_ttl(ttl),
+        refresh_ttl,
+        truncate_back_to_size,
+    )
+    .map_err(Into::into)
+}
+
+/// Pop a value from the front of a list in the cache.
+///
+/// Returns `None` if the list does not exist, or `Some((value, list_length))` if a value was popped.
+/// The `list_length` is the length of the list after the pop operation.
+///
+/// Examples:
+/// ________
+/// Bytes:
+/// ```rust
+/// # use momento_functions_host::cache;
+/// # use momento_functions_host::cache::CacheListPopError;
+///
+/// # fn f() -> Result<(), CacheListPopError<Vec<u8>>> {
+/// let result: Option<(Vec<u8>, u32)> = cache::list_pop_front("my_list")?;
+/// # Ok(()) }
+/// ```
+/// ________
+/// Json:
+/// ```rust
+/// # use momento_functions_host::cache;
+/// # use momento_functions_host::cache::CacheListPopError;
+/// use momento_functions_host::encoding::Json;
+///
+/// #[derive(serde::Deserialize)]
+/// struct MyStruct {
+///   message: String
+/// }
+///
+/// # fn f() -> Result<(), CacheListPopError<Json<MyStruct>>> {
+/// let result: Option<(Json<MyStruct>, u32)> = cache::list_pop_front("my_list")?;
+/// # Ok(()) }
+/// ```
+pub fn list_pop_front<T: Extract>(
+    list_name: impl AsRef<[u8]>,
+) -> Result<Option<(T, u32)>, CacheListPopError<T::Error>> {
+    match cache_list::list_pop_front(list_name.as_ref())? {
+        cache_list::PopResponse::Found(pop_found) => {
+            let value = T::extract(pop_found.value)
+                .map_err(|e| CacheListPopError::ExtractFailed { cause: e })?;
+            Ok(Some((value, pop_found.list_length)))
+        }
+        cache_list::PopResponse::Missing => Ok(None),
+    }
+}
+
+/// Pop a value from the back of a list in the cache.
+///
+/// Returns `None` if the list does not exist, or `Some((value, list_length))` if a value was popped.
+/// The `list_length` is the length of the list after the pop operation.
+///
+/// Examples:
+/// ________
+/// Bytes:
+/// ```rust
+/// # use momento_functions_host::cache;
+/// # use momento_functions_host::cache::CacheListPopError;
+///
+/// # fn f() -> Result<(), CacheListPopError<Vec<u8>>> {
+/// let result: Option<(Vec<u8>, u32)> = cache::list_pop_back("my_list")?;
+/// # Ok(()) }
+/// ```
+/// ________
+/// Json:
+/// ```rust
+/// # use momento_functions_host::cache;
+/// # use momento_functions_host::cache::CacheListPopError;
+/// use momento_functions_host::encoding::Json;
+///
+/// #[derive(serde::Deserialize)]
+/// struct MyStruct {
+///   message: String
+/// }
+///
+/// # fn f() -> Result<(), CacheListPopError<Json<MyStruct>>> {
+/// let result: Option<(Json<MyStruct>, u32)> = cache::list_pop_back("my_list")?;
+/// # Ok(()) }
+/// ```
+pub fn list_pop_back<T: Extract>(
+    list_name: impl AsRef<[u8]>,
+) -> Result<Option<(T, u32)>, CacheListPopError<T::Error>> {
+    match cache_list::list_pop_back(list_name.as_ref())? {
+        cache_list::PopResponse::Found(pop_found) => {
+            let value = T::extract(pop_found.value)
+                .map_err(|e| CacheListPopError::ExtractFailed { cause: e })?;
+            Ok(Some((value, pop_found.list_length)))
+        }
+        cache_list::PopResponse::Missing => Ok(None),
+    }
 }

--- a/momento-functions-wit/wit/cache-list.wit
+++ b/momento-functions-wit/wit/cache-list.wit
@@ -1,0 +1,147 @@
+interface cache-list {
+    variant error {
+        internal-error,
+        request-cancelled,
+        invalid-argument(string),
+        timeout,
+        permission-denied(string),
+        limit-exceeded(string),
+        failed-precondition(string),
+        not-found(string),
+    }
+
+    record pop-found {
+        value: list<u8>,
+        list-length: u32,
+    }
+
+    record list-range {
+        begin-index: u32,
+        count: u32,
+    }
+
+    record list-ranges {
+        ranges: list<list-range>,
+    }
+
+    variant pop-response {
+        found(pop-found),
+        missing,
+    }
+
+    variant erase-range {
+        all,
+        ranges(list-ranges),
+    }
+
+    variant erase-response {
+        /// Length of list after erasing
+        found(u32),
+        missing,
+    }
+
+    variant remove-response {
+        /// Length of list after erasing
+        found(u32),
+        missing,
+    }
+
+    variant remove-range {
+        all-elements-with-value(list<u8>),
+    }
+
+    variant start-index {
+        unbounded,
+        inclusive(s32),
+    }
+
+    variant end-index {
+        unbounded,
+        exclusive(s32),
+    }
+
+    variant fetch-response {
+        found(list<u8>),
+        missing,
+    }
+
+    variant length-response {
+        /// Length of list
+        found(u32),
+        missing,
+    }
+
+    variant retain-response {
+        /// Length of list after the operation is completed
+        found(u32),
+        missing,
+    }
+
+    list-push-front: func(
+        list-name: list<u8>,
+        value: list<u8>,
+        ttl-milliseconds: u64,
+        refresh-ttl: bool,
+        truncate-back-to-size: u32
+    ) -> result<u32, error>;
+
+    list-push-back: func(
+        list-name: list<u8>,
+        value: list<u8>,
+        ttl-milliseconds: u64,
+        refresh-ttl: bool,
+        truncate-back-to-size: u32
+    ) -> result<u32, error>;
+
+    list-pop-front: func(
+        list-name: list<u8>
+    ) -> result<pop-response, error>;
+
+    list-pop-back: func(
+        list-name: list<u8>
+    ) -> result<pop-response, error>;
+
+    list-erase: func(
+        list-name: list<u8>,
+        range: erase-range
+    ) -> result<erase-response, error>;
+
+    list-remove: func(
+        list-name: list<u8>,
+        range: remove-range
+    ) -> result<remove-response, error>;
+
+    list-fetch: func(
+        list-name: list<u8>,
+        start: start-index,
+        end: end-index
+    ) -> result<fetch-response, error>;
+
+    list-length: func(
+        list-name: list<u8>
+    ) -> result<length-response, error>;
+
+    list-concatenate-front: func(
+        list-name: list<u8>,
+        values: list<list<u8>>,
+        ttl-milliseconds: u64,
+        refresh-ttl: bool,
+        truncate-back-to-size: u32
+    ) -> result<u32, error>;
+
+    list-concatenate-back: func(
+        list-name: list<u8>,
+        values: list<list<u8>>,
+        ttl-milliseconds: u64,
+        refresh-ttl: bool,
+        truncate-back-to-size: u32
+    ) -> result<u32, error>;
+
+    list-retain: func(
+        list-name: list<u8>,
+        start: start-index,
+        end: end-index,
+        ttl-milliseconds: u64,
+        refresh-ttl: bool
+    ) -> result<retain-response, error>;
+}

--- a/momento-functions-wit/wit/world.wit
+++ b/momento-functions-wit/wit/world.wit
@@ -3,6 +3,7 @@ package momento:functions@1.0.0;
 world host {
     include momento:host/imports@1.0.0;
 
+    import cache-list;
     import cache-scalar;
     import token;
     import topic;

--- a/momento-functions/Cargo.toml
+++ b/momento-functions/Cargo.toml
@@ -11,6 +11,10 @@ keywords.workspace = true
 categories.workspace = true
 
 [[example]]
+name = "cache-list"
+crate-type = ["cdylib"]
+
+[[example]]
 name = "dynamodb-accelerator"
 crate-type = ["cdylib"]
 

--- a/momento-functions/examples/cache-list.rs
+++ b/momento-functions/examples/cache-list.rs
@@ -1,0 +1,82 @@
+//! Simple example showcasing how you can use Momento's List API within a function.
+//!
+//! To see this "working," you'll want to subscribe to the log topic to see results.
+//! You can do so via:
+//! ```
+//! momento topic subscribe --cache-name <your-cache> cache-list
+//! ```
+use momento_functions::{WebResponse, WebResult};
+use momento_functions_host::{cache, encoding::Json, logging::LogDestination};
+use serde::Serialize;
+use std::time::Duration;
+
+#[derive(Debug, Serialize)]
+struct Response {
+    message: String,
+}
+
+momento_functions::post!(cache_list);
+fn cache_list(_payload: Vec<u8>) -> WebResult<WebResponse> {
+    momento_functions_log::configure_logs([LogDestination::topic("cache-list").into()])?;
+
+    let list_name = "my_list";
+    let ttl = Duration::from_secs(15);
+
+    // Push some values to the front
+    log::info!("Pushing 'first' to front of list");
+    let length = cache::list_push_front(
+        list_name,
+        b"first".to_vec(),
+        ttl,
+        // You can set this to 'true' to refresh the ttl if you need to
+        false,
+        // truncate list to 100 items from the back, which should cover our single value
+        100,
+    )?;
+    log::info!("List length after push_front: {}", length);
+
+    log::info!("Pushing 'second' to front of list");
+    let length = cache::list_push_front(list_name, b"second".to_vec(), ttl, true, 100)?;
+    log::info!("List length after push_front: {}", length);
+
+    // Push some values to the back
+    log::info!("Pushing 'third' to back of list");
+    let length = cache::list_push_back(list_name, b"third".to_vec(), ttl, true, 100)?;
+    log::info!("List length after push_back: {}", length);
+
+    log::info!("Pushing 'fourth' to back of list");
+    let length = cache::list_push_back(list_name, b"fourth".to_vec(), ttl, true, 100)?;
+    log::info!("List length after push_back: {}", length);
+
+    // Pop from the front
+    log::info!("Popping from front of list");
+    match cache::list_pop_front::<Vec<u8>>(list_name)? {
+        Some((value, length)) => {
+            let value_str = String::from_utf8_lossy(&value);
+            log::info!(
+                "Popped '{}' from front, list length now: {}",
+                value_str,
+                length
+            );
+        }
+        None => log::warn!("List was empty"),
+    }
+
+    // Pop from the back
+    log::info!("Popping from back of list");
+    match cache::list_pop_back::<Vec<u8>>(list_name)? {
+        Some((value, length)) => {
+            let value_str = String::from_utf8_lossy(&value);
+            log::info!(
+                "Popped '{}' from back, list length now: {}",
+                value_str,
+                length
+            );
+        }
+        None => log::warn!("List was empty"),
+    }
+
+    Ok(WebResponse::new().with_body(Json(Response {
+        message: "Done! Check your logs for the results".to_string(),
+    }))?)
+}


### PR DESCRIPTION
This is the groundwork for hooking up Momento's `list` APIs as exposed host interfaces. This is not feature-complete, but a good starting point. A basic example is included to showcase some basic usage.

