### PR TITLE
add v2 wits, bytes, and guest-web crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -511,6 +511,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "momento-functions-bytes"
+version = "0.12.0"
+dependencies = [
+ "serde",
+ "serde_json",
+ "wit-bindgen",
+]
+
+[[package]]
+name = "momento-functions-guest-web"
+version = "0.12.0"
+dependencies = [
+ "momento-functions-bytes",
+ "serde",
+ "serde_json",
+ "wit-bindgen",
+]
+
+[[package]]
 name = "momento-functions-host"
 version = "0.12.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,8 @@
 resolver = "2"
 
 members = [
+    "bytes",
+    "guest-web",
     "momento-functions",
     "momento-functions-host",
     "momento-functions-log",
@@ -22,6 +24,7 @@ categories = ["web-programming"]
 lto = true
 
 [workspace.dependencies]
+momento-functions-bytes = { version = "0", path = "bytes" }
 momento-functions-host  = { version = "0", path = "momento-functions-host" }
 momento-functions-log   = { version = "0", path = "momento-functions-log" }
 momento-functions-wit   = { version = "0", path = "momento-functions-wit" }

--- a/bytes/Cargo.toml
+++ b/bytes/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "momento-functions-bytes"
+description = "off-guest buffer management"
+version.workspace = true
+authors.workspace = true
+repository.workspace = true
+edition.workspace = true
+license.workspace = true
+readme.workspace = true
+keywords.workspace = true
+categories.workspace = true
+
+[dependencies]
+wit-bindgen             = { workspace = true }
+serde                   = { workspace = true }
+serde_json              = { workspace = true }

--- a/bytes/src/data.rs
+++ b/bytes/src/data.rs
@@ -1,0 +1,91 @@
+/// A buffer of bytes, which may be inline or on the host.
+///
+/// Some bulk data processing Functions may choose to pass data straight from a
+/// request or response body to another request or response body. To improve
+/// performance on these kinds of Functions, `Data` avoids copying the buffer
+/// into your function's memory.
+#[derive(Debug)]
+pub struct Data {
+    data: Location,
+}
+
+impl Data {
+    /// Turn the Data into a plain `Vec<u8>`.
+    ///
+    /// If the data is buffered on the host, this will read the buffer completely
+    /// into your function's memory. You should use this with caution!
+    ///
+    /// For small buffers, this is inconsequential. For larger buffers, this may
+    /// cause your function to run out of memory or to run slowly.
+    pub fn into_bytes(self) -> Vec<u8> {
+        self.data.into_bytes()
+    }
+}
+
+impl From<Vec<u8>> for Data {
+    fn from(value: Vec<u8>) -> Self {
+        Self {
+            data: Location::Inline { buffer: value },
+        }
+    }
+}
+
+impl From<crate::wit::momento::bytes::bytes::Data> for Data {
+    fn from(value: crate::wit::momento::bytes::bytes::Data) -> Self {
+        match value {
+            crate::wit::momento::bytes::bytes::Data::Value(buffer) => Self {
+                data: Location::Inline { buffer },
+            },
+            crate::wit::momento::bytes::bytes::Data::Buffer(resource) => Self {
+                data: Location::OnHost { resource },
+            },
+        }
+    }
+}
+
+enum Location {
+    Inline {
+        buffer: Vec<u8>,
+    },
+    OnHost {
+        resource: crate::wit::momento::bytes::bytes::Buffer,
+    },
+}
+impl Location {
+    fn into_bytes(self) -> Vec<u8> {
+        match self {
+            Location::Inline { buffer } => buffer,
+            Location::OnHost { resource } => {
+                let mut buffer = Vec::with_capacity(resource.remaining() as usize);
+                while let Some(chunk) = resource.read(resource.remaining().max(16384)) {
+                    buffer.extend(chunk);
+                }
+                buffer
+            }
+        }
+    }
+}
+
+impl std::fmt::Debug for Location {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Location::Inline { buffer } => f
+                .debug_struct("Inline")
+                .field("length", &buffer.len())
+                .finish(),
+            Location::OnHost { resource } => f
+                .debug_struct("OnHost")
+                .field("remaining", &resource.remaining())
+                .finish(),
+        }
+    }
+}
+
+impl From<Data> for crate::wit::momento::bytes::bytes::Data {
+    fn from(data: Data) -> Self {
+        match data.data {
+            Location::Inline { buffer } => Self::Value(buffer),
+            Location::OnHost { resource } => Self::Buffer(resource),
+        }
+    }
+}

--- a/bytes/src/encoding.rs
+++ b/bytes/src/encoding.rs
@@ -1,0 +1,112 @@
+//! Encoding and decoding of byte array payloads
+
+use std::convert::Infallible;
+
+use crate::Data;
+
+/// Required to be implemented by encode error types.
+pub trait EncodeError: std::error::Error + 'static {}
+
+impl EncodeError for Infallible {}
+
+impl EncodeError for serde_json::Error {}
+
+/// A payload which can be converted to a vector of bytes
+pub trait Encode {
+    /// The error type returned when encoding fails.
+    type Error: EncodeError;
+    /// Convert the payload to a vector of bytes
+    fn try_serialize(self) -> Result<Data, Self::Error>;
+}
+
+impl Encode for Vec<u8> {
+    type Error = Infallible;
+    fn try_serialize(self) -> Result<Data, Self::Error> {
+        Ok(self.into())
+    }
+}
+impl Encode for &[u8] {
+    type Error = Infallible;
+    fn try_serialize(self) -> Result<Data, Self::Error> {
+        Ok(self.to_vec().into())
+    }
+}
+impl Encode for String {
+    type Error = Infallible;
+    fn try_serialize(self) -> Result<Data, Self::Error> {
+        Ok(self.into_bytes().into())
+    }
+}
+impl Encode for &str {
+    type Error = Infallible;
+    fn try_serialize(self) -> Result<Data, Self::Error> {
+        Ok(self.as_bytes().to_vec().into())
+    }
+}
+impl Encode for Option<Vec<u8>> {
+    type Error = Infallible;
+    fn try_serialize(self) -> Result<Data, Self::Error> {
+        match self {
+            Some(v) => Ok(v.into()),
+            None => Ok(Vec::new().into()),
+        }
+    }
+}
+impl Encode for () {
+    type Error = Infallible;
+    fn try_serialize(self) -> Result<Data, Self::Error> {
+        Ok(Vec::new().into())
+    }
+}
+impl Encode for serde_json::Value {
+    type Error = serde_json::Error;
+    fn try_serialize(self) -> Result<Data, Self::Error> {
+        serde_json::to_vec(&self).map(Into::into)
+    }
+}
+
+/// Required to be implemented by extract error types.
+pub trait ExtractError: std::error::Error + 'static {}
+
+impl ExtractError for Infallible {}
+
+impl ExtractError for serde_json::Error {}
+
+/// Payload extractor for encodings
+pub trait Extract: Sized {
+    /// The error type returned when extraction fails.
+    type Error: ExtractError;
+    /// Convert from a payload to a value
+    fn extract(payload: Data) -> Result<Self, Self::Error>;
+}
+
+impl Extract for Vec<u8> {
+    type Error = Infallible;
+    fn extract(payload: Data) -> Result<Self, Self::Error> {
+        Ok(payload.into_bytes())
+    }
+}
+
+impl Extract for Data {
+    type Error = Infallible;
+
+    fn extract(payload: Data) -> Result<Self, Self::Error> {
+        Ok(payload)
+    }
+}
+
+/// JSON encoding and decoding
+pub struct Json<T>(pub T);
+impl<T: serde::de::DeserializeOwned> Extract for Json<T> {
+    type Error = serde_json::Error;
+    fn extract(payload: Data) -> Result<Self, Self::Error> {
+        Ok(Json(serde_json::from_slice(&payload.into_bytes())?))
+    }
+}
+
+impl<T: serde::Serialize> Encode for Json<T> {
+    type Error = serde_json::Error;
+    fn try_serialize(self) -> Result<Data, Self::Error> {
+        serde_json::to_vec(&self.0).map(Into::into)
+    }
+}

--- a/bytes/src/lib.rs
+++ b/bytes/src/lib.rs
@@ -1,0 +1,14 @@
+//! Off-guest buffer management.
+//!
+//! This crate provides the `Data` type, which is a buffer of bytes that may be
+//! stored on the host. This allows you to pass data from a request or response
+//! to another request or response without copying it into your function's memory.
+//! This can improve performance for large buffers, when you're passing data through.
+
+mod data;
+/// Internal module for WIT bindings.
+#[doc(hidden)]
+pub mod wit;
+
+pub use data::Data;
+pub mod encoding;

--- a/bytes/src/wit.rs
+++ b/bytes/src/wit.rs
@@ -1,0 +1,4 @@
+wit_bindgen::generate!({
+    world: "momento:bytes/imports",
+    path: ["../wit/host/"],
+});

--- a/guest-web/Cargo.toml
+++ b/guest-web/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "momento-functions-guest-web"
+description = "Guest bindings for Momento Web Functions"
+version.workspace = true
+authors.workspace = true
+repository.workspace = true
+edition.workspace = true
+license.workspace = true
+readme.workspace = true
+keywords.workspace = true
+categories.workspace = true
+
+[[example]]
+name = "echo"
+crate-type = ["cdylib"]
+
+[[example]]
+name = "greet"
+crate-type = ["cdylib"]
+
+[dependencies]
+momento-functions-bytes = { workspace = true }
+
+serde                   = { workspace = true }
+serde_json              = { workspace = true }
+wit-bindgen             = { workspace = true }
+
+[dev-dependencies]

--- a/guest-web/examples/echo.rs
+++ b/guest-web/examples/echo.rs
@@ -1,0 +1,16 @@
+//! An example Function that echoes the request body back in the response.
+//!
+//! Note that this example uses the [momento_functions_bytes::Data] type,
+//! which allows the actual payload to stay out of WASM memory. This is
+//! ideal for large messages, or data that you only want to pass through.
+//! Keeping the data on the host makes your Function run much more quickly.
+//!
+//! Invoke this Function with any body and it will echo it back as an `application/octet-stream`.
+
+use momento_functions_bytes::Data;
+use momento_functions_guest_web::invoke;
+
+invoke!(echo);
+fn echo(request: Data) -> Data {
+    request
+}

--- a/guest-web/examples/greet.rs
+++ b/guest-web/examples/greet.rs
@@ -1,0 +1,27 @@
+//! An example Function that receives a JSON payload and returns a JSON response.
+//!
+//! This is a typed hello world.
+//!
+//! Invoke this Function with a JSON body like `{"name": "kvc"}` and it will respond with `{"message": "Hello, kvc!"}`.
+
+use core::str;
+
+use momento_functions_bytes::encoding::Json;
+use momento_functions_guest_web::invoke;
+
+#[derive(serde::Deserialize)]
+struct Request {
+    name: String,
+}
+
+#[derive(serde::Serialize)]
+struct Response {
+    message: String,
+}
+
+invoke!(greet);
+fn greet(Json(request): Json<Request>) -> Json<Response> {
+    let Request { name } = request;
+    let message = format!("Hello, {}!", name);
+    Json(Response { message })
+}

--- a/guest-web/src/function_web.rs
+++ b/guest-web/src/function_web.rs
@@ -1,0 +1,103 @@
+use crate::wit::exports::momento::web_function::guest_function_web;
+use momento_functions_bytes::encoding::Extract;
+
+use crate::IntoWebResponse;
+/// Create a handler that accepts a post payload and returns a response.
+///
+/// You can accept raw bytes (`Vec<u8>`) as input, or any type for which [Extract] is implemented.
+/// If you choose to use an extracted type, this will automatically return a 400 error containing
+/// the error details if the input bytes cannot be extracted into the specified input type.
+/// If you would rather handle extraction errors yourself, you should accept raw bytes as input
+/// and perform extraction yourself.
+///
+/// Your implementation function must return a value which implements the [IntoWebResponse] trait.
+/// Implementations of this trait are provided for
+/// - [crate::WebResponse]: A basic response representation and builder
+/// - `WebResult<impl IntoWebResponse>`: Allows you to return results where errors will be converted
+///   to 500 responses.
+/// - [()]: Results in an empty 204.
+/// - [String] and [&str]: Results in a 200 with the string body.
+/// - `Vec<u8>` and `&[u8]`: Results in a 200 with the binary body.
+/// - [momento_functions_bytes::encoding::Json]: Results in a 200 with the Json body, or a 500 if the Json could not be serialized.
+///
+/// You may also implement [IntoWebResponse] for your own types.
+///
+/// **Raw Bytes Input:**
+/// ```rust
+/// use std::error::Error;
+///
+/// use momento_functions_bytes::Data;
+/// use momento_functions_guest_web::{invoke, WebResponse};
+///
+/// invoke!(ping);
+/// fn ping(payload: Data) -> &'static str {
+///     "pong"
+/// }
+/// ```
+///
+/// **Typed JSON Input:**
+/// ```rust
+/// use std::error::Error;
+///
+/// use momento_functions_guest_web::{invoke, WebResponse};
+/// use momento_functions_bytes::encoding::Json;
+///
+/// #[derive(serde::Deserialize)]
+/// struct Request {
+///     name: String,
+/// }
+/// #[derive(serde::Serialize)]
+/// struct Response {
+///     message: String,
+/// }
+///
+/// invoke!(greet);
+/// fn greet(Json(request): Json<Request>) -> Json<Response> {
+///     Json(Response { message: format!("Hello, {}!", request.name) })
+/// }
+/// ```
+#[macro_export]
+macro_rules! invoke {
+    ($post_handler: ident) => {
+        struct WebFunction;
+        momento_functions_guest_web::wit::export_web_function!(WebFunction);
+
+        #[automatically_derived]
+        impl momento_functions_guest_web::wit::exports::momento::web_function::guest_function_web::Guest for WebFunction {
+            fn invoke(request: momento_functions_guest_web::wit::exports::momento::web_function::guest_function_web::Data) -> momento_functions_guest_web::wit::exports::momento::web_function::guest_function_web::Response {
+                momento_functions_guest_web::invoke_template(request, $post_handler)
+            }
+        }
+    };
+}
+
+/// An internal helper for the invoke! macro.
+#[doc(hidden)]
+#[allow(unused)]
+pub fn invoke_template<TExtract, TResponse>(
+    payload: guest_function_web::Data,
+    handler: fn(request: TExtract) -> TResponse,
+) -> guest_function_web::Response
+where
+    TExtract: Extract,
+    TResponse: IntoWebResponse,
+{
+    let payload: momento_functions_bytes::Data = payload.into();
+    let request = match TExtract::extract(payload) {
+        Ok(request) => request,
+        Err(error) => {
+            return guest_function_web::Response {
+                status: 400,
+                headers: vec![],
+                body: momento_functions_bytes::Data::from(
+                    format!("Failed to parse request body: {error}")
+                        .to_string()
+                        .as_bytes()
+                        .to_vec(),
+                )
+                .into(),
+            };
+        }
+    };
+    handler(request).response()
+}

--- a/guest-web/src/into_web_response.rs
+++ b/guest-web/src/into_web_response.rs
@@ -1,0 +1,134 @@
+use crate::wit::exports::momento::web_function::guest_function_web::Response;
+use momento_functions_bytes::{
+    Data,
+    encoding::{Encode, Json},
+};
+use serde::Serialize;
+
+macro_rules! content_type {
+    ($content_type:expr) => {
+        vec![("content-type".to_string(), $content_type.to_string())]
+            .into_iter()
+            .map(Into::into)
+            .collect()
+    };
+}
+
+/// Values returned by a function implemented with the [crate::invoke!] macro must implement this trait.
+pub trait IntoWebResponse {
+    fn response(self) -> Response;
+}
+
+impl IntoWebResponse for Vec<u8> {
+    fn response(self) -> Response {
+        Response {
+            status: 200,
+            headers: content_type!("application/octet-stream"),
+            body: Data::from(self).into(),
+        }
+    }
+}
+
+impl IntoWebResponse for &[u8] {
+    fn response(self) -> Response {
+        Response {
+            status: 200,
+            headers: content_type!("application/octet-stream"),
+            body: Data::from(self.to_vec()).into(),
+        }
+    }
+}
+
+impl IntoWebResponse for String {
+    fn response(self) -> Response {
+        Response {
+            status: 200,
+            headers: content_type!("text/plain; charset=utf-8"),
+            body: Data::from(self.into_bytes()).into(),
+        }
+    }
+}
+
+impl IntoWebResponse for &str {
+    fn response(self) -> Response {
+        Response {
+            status: 200,
+            headers: content_type!("text/plain; charset=utf-8"),
+            body: Data::from(self.to_string().into_bytes()).into(),
+        }
+    }
+}
+
+impl IntoWebResponse for () {
+    fn response(self) -> Response {
+        Response {
+            status: 204,
+            headers: vec![],
+            body: Data::from(Vec::new()).into(),
+        }
+    }
+}
+
+impl IntoWebResponse for Option<Vec<u8>> {
+    fn response(self) -> Response {
+        Response {
+            status: 200,
+            headers: content_type!("application/octet-stream"),
+            body: Data::from(self.unwrap_or_default()).into(),
+        }
+    }
+}
+
+impl IntoWebResponse for Option<String> {
+    fn response(self) -> Response {
+        Response {
+            status: 200,
+            headers: content_type!("text/plain; charset=utf-8"),
+            body: Data::from(self.unwrap_or_default().into_bytes()).into(),
+        }
+    }
+}
+
+impl IntoWebResponse for serde_json::Value {
+    fn response(self) -> Response {
+        match serde_json::to_vec(&self) {
+            Ok(body) => Response {
+                status: 200,
+                headers: content_type!("application/json; charset=utf-8"),
+                body: Data::from(body).into(),
+            },
+            Err(e) => Response {
+                status: 500,
+                headers: content_type!("text/plain; charset=utf-8"),
+                body: Data::from(format!("Failed to encode response: {e}").into_bytes()).into(),
+            },
+        }
+    }
+}
+
+impl<T: Serialize> IntoWebResponse for Json<T> {
+    fn response(self) -> Response {
+        match self.try_serialize() {
+            Ok(body) => Response {
+                status: 200,
+                headers: content_type!("application/json; charset=utf-8"),
+                body: body.into(),
+            },
+            Err(e) => Response {
+                status: 500,
+                headers: content_type!("text/plain; charset=utf-8"),
+                body: Data::from(format!("Failed to encode response: {e}").into_bytes()).into(),
+            },
+        }
+    }
+}
+
+impl IntoWebResponse for momento_functions_bytes::Data {
+    fn response(self) -> Response {
+        Response {
+            status: 200,
+            headers: content_type!("application/octet-stream"),
+            body: self.into(),
+        }
+    }
+}

--- a/guest-web/src/lib.rs
+++ b/guest-web/src/lib.rs
@@ -1,0 +1,14 @@
+mod function_web;
+mod into_web_response;
+mod response;
+mod web_environment;
+/// Internal module for WIT bindings.
+#[doc(hidden)]
+pub mod wit;
+
+pub use function_web::invoke_template;
+pub use into_web_response::IntoWebResponse;
+pub use response::WebError;
+pub use response::WebResponse;
+pub use response::WebResult;
+pub use web_environment::WebEnvironment;

--- a/guest-web/src/response.rs
+++ b/guest-web/src/response.rs
@@ -1,0 +1,136 @@
+use crate::IntoWebResponse;
+use crate::wit::exports::momento::web_function::guest_function_web::Response;
+use momento_functions_bytes::Data;
+use momento_functions_bytes::encoding::Encode;
+use std::error::Error;
+use std::fmt::{Debug, Display, Formatter};
+
+/// A WebError represents an error result produced by a function execution.
+/// Functionally, it is also just an HTTP response - however, this allows for writing
+/// functions with a return signature of `WebResult` if you are okay with all errors
+/// being converted to 500s and returned in the body.
+#[derive(Debug)]
+pub struct WebError {
+    source: Option<Box<dyn Error>>,
+    response: WebResponse,
+}
+
+impl WebError {
+    pub fn message(message: impl Into<String>) -> Self {
+        let message = message.into();
+        let response = WebResponse {
+            status: 500,
+            headers: vec![],
+            body: message.as_bytes().to_vec().into(),
+        };
+        Self {
+            source: None,
+            response,
+        }
+    }
+}
+
+impl<E: Error + 'static> From<E> for WebError {
+    fn from(e: E) -> Self {
+        let body = format!("An error occurred during function invocation: {e}");
+        Self {
+            source: Some(Box::new(e)),
+            response: WebResponse {
+                status: 500,
+                headers: vec![],
+                body: body.into_bytes().into(),
+            },
+        }
+    }
+}
+
+impl Display for WebError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "WebError(Source: {:?})", self.source)
+    }
+}
+
+/// A Result type for implementing functions. Allows you to use `?` within your function body
+/// to return a 500 with the error details.
+pub type WebResult<T> = Result<T, WebError>;
+
+impl<R> IntoWebResponse for Result<R, WebError>
+where
+    R: IntoWebResponse,
+{
+    fn response(self) -> Response {
+        match self {
+            Ok(r) => r.response(),
+            Err(e) => e.response.response(),
+        }
+    }
+}
+
+/// This represents a response from a web function.
+/// When constructed, it's a 200 response with no headers or body.
+/// You can set the status, headers, and body via [WebResponse::with_status], [WebResponse::with_headers],
+/// and [WebResponse::with_body] respectfully.
+#[derive(Debug)]
+pub struct WebResponse {
+    status: u16,
+    headers: Vec<(String, String)>,
+    body: Data,
+}
+
+impl Default for WebResponse {
+    fn default() -> Self {
+        Self {
+            status: 200,
+            headers: vec![],
+            body: vec![].into(),
+        }
+    }
+}
+
+impl WebResponse {
+    /// Creates a new default response.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Sets the response status.
+    pub fn with_status(mut self, status: u16) -> Self {
+        self.status = status;
+        self
+    }
+
+    /// Adds a header to the response.
+    pub fn header(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.headers.push((key.into(), value.into()));
+        self
+    }
+
+    /// Overrides the collection of headers for the response.
+    pub fn with_headers(mut self, headers: Vec<(String, String)>) -> Self {
+        self.headers = headers;
+        self
+    }
+
+    /// Sets the response body. If encoding the body fails, returns an error.
+    pub fn with_body<E: Encode>(mut self, body: E) -> Result<Self, E::Error> {
+        let body = body.try_serialize()?;
+        self.body = body;
+        Ok(self)
+    }
+}
+
+impl IntoWebResponse for WebResponse {
+    fn response(self) -> Response {
+        Response {
+            status: self.status,
+            headers: self.headers.into_iter().map(Into::into).collect(),
+            body: self.body.into(),
+        }
+    }
+}
+
+impl From<(String, String)> for crate::wit::momento::web_function::web_function_support::Header {
+    fn from((name, value): (String, String)) -> Self {
+        Self { name, value }
+    }
+}

--- a/guest-web/src/web_environment.rs
+++ b/guest-web/src/web_environment.rs
@@ -1,0 +1,163 @@
+//! Host interface extensions for Web Functions
+//!
+//! These interfaces don't do anything on other kinds of Functions.
+
+use std::{collections::HashMap, env, sync::LazyLock};
+
+use crate::wit::momento::web_function::web_function_support;
+
+static NOT_FOUND: &str = "<not found>";
+// Some of the Momento host interfaces will take ownership of the returned value, returning
+// a `None` or empty-like object upon repeated calls. These `OnceLocks` allow for repeated
+// calls since the data is not intended to be mutated anyway.
+static GET_ENVIRONMENT_ONCE: LazyLock<WebEnvironment> = LazyLock::new(|| {
+    let cache_name = env::var("__CACHE_NAME").unwrap_or(NOT_FOUND.to_string());
+    let function_name = env::var("__FUNCTION_NAME").unwrap_or(NOT_FOUND.to_string());
+    let invocation_id = env::var("__INVOCATION_ID").unwrap_or(NOT_FOUND.to_string());
+    WebEnvironment {
+        cache_name,
+        function_name,
+        invocation_id,
+    }
+});
+static GET_HEADERS_ONCE: LazyLock<HashMap<String, String>> = LazyLock::new(|| {
+    web_function_support::headers()
+        .into_iter()
+        .map(|web_function_support::Header { name, value }| (name, value))
+        .collect()
+});
+// Yes, this is a hashmap, but query parameters can be repeated. Usually people don't do that though.
+static GET_QUERY_PARAMETERS_ONCE: LazyLock<HashMap<String, String>> = LazyLock::new(|| {
+    web_function_support::query_parameters()
+        .into_iter()
+        .map(|web_function_support::QueryParameter { name, value }| (name, value))
+        .collect()
+});
+static GET_TOKEN_METADATA_ONCE: LazyLock<Option<String>> =
+    LazyLock::new(web_function_support::token_metadata);
+static GET_HTTP_METHOD_ONCE: LazyLock<String> = LazyLock::new(web_function_support::http_method);
+static GET_HTTP_PATH_ONCE: LazyLock<String> =
+    LazyLock::new(|| web_function_support::invocation_path().unwrap_or_default());
+
+/// Data structure containing easy-to-access information regarding the current invocation's
+/// environment. Momento will populate this information as necessary, either through provided
+/// environment variables normally accessible via `std::env::var()`, or interfaces across the WASI
+/// bridge. For best practices/avoiding variable typos, a constructor has been provided:
+/// ```rust,no_run
+/// use momento_functions_host::web_extensions::FunctionEnvironment;
+/// let function_environment = FunctionEnvironment::get_function_environment();
+///
+/// // Examples
+/// log::info!("Cache: {}", function_environment::cache());
+/// log::info!("Invocation ID: {}", function_environment::invocation_id());
+///
+/// let joined_query_parameters = function_environment::query_parameters()
+///     .iter()
+///     .map(|(k, v)| format!("{k}={v}"))
+///     .collect::<Vec<_>>()
+///     .join(", ");
+/// log::info!("Called with query parameters: {joined_query_parameters}");
+/// ```
+pub struct WebEnvironment {
+    cache_name: String,
+    function_name: String,
+    invocation_id: String,
+}
+
+impl WebEnvironment {
+    /// Returns a singleton object containing useful information regarding the current function invocation's
+    /// environment. This is safe to call multiple times. It is recommended to use this object when trying to
+    /// access the environment variables populated upon function creation.
+    pub fn load() -> &'static WebEnvironment {
+        &GET_ENVIRONMENT_ONCE
+    }
+
+    /// The name of the cache this function belongs to. You can also access this via:
+    /// ```rust
+    /// let cache_name = std:env::var("__CACHE_NAME").unwrap_or_default();
+    /// ```
+    pub fn cache_name(&self) -> &String {
+        &self.cache_name
+    }
+
+    /// The name of the function. You can also access this via:
+    /// ```rust
+    /// let function_name = std:env::var("__FUNCTION_NAME").unwrap_or_default();
+    /// ```
+    pub fn function_name(&self) -> &String {
+        &self.function_name
+    }
+
+    /// The ID of the currently executing invocation. You can also access this via:
+    /// ```rust
+    /// let invocation_id = std:env::var("__INVOCATION_ID").unwrap_or_default();
+    /// ```
+    pub fn invocation_id(&self) -> &String {
+        &self.invocation_id
+    }
+
+    /// A map of the headers used in the request when the function was invoked. You can also access this via:
+    /// ```rust,no_run
+    /// use momento_functions_host::web_extensions::headers;
+    /// let headers = headers();
+    /// ```
+    pub fn headers(&self) -> &HashMap<String, String> {
+        headers()
+    }
+
+    /// A map of the query parameters used in the request when the function was invoked. You can also access this via:
+    /// ```rust,no_run
+    /// use momento_functions_host::web_extensions::query_parameters;
+    /// let query_parameters = query_parameters();
+    /// ```
+    pub fn query_parameters(&self) -> &HashMap<String, String> {
+        query_parameters()
+    }
+
+    /// The metadata within the caller's token, if present. You can also access this via:
+    /// ```rust,no_run
+    /// use momento_functions_host::web_extensions::token_metadata;
+    /// let token_metadata = token_metadata();
+    /// ```
+    pub fn token_metadata(&self) -> &Option<String> {
+        token_metadata()
+    }
+
+    /// The HTTP method used in the request when the function was invoked.
+    /// "GET", "POST", etc.
+    pub fn http_method(&self) -> &str {
+        &GET_HTTP_METHOD_ONCE
+    }
+
+    /// The HTTP path used in the request when the function was invoked.
+    ///
+    /// This is the path relative to the function. If your function is deployed at
+    /// `https://gomomento.com/my-function`, and you call
+    /// `https://gomomento.com/my-function/search/me`, this will return `/search/me`.
+    pub fn http_path(&self) -> &str {
+        &GET_HTTP_PATH_ONCE
+    }
+}
+
+/// Returns the headers for the web function, if any are present.
+pub fn headers() -> &'static HashMap<String, String> {
+    &GET_HEADERS_ONCE
+}
+
+/// Returns the query parameters for the web function, if any are present.
+pub fn query_parameters() -> &'static HashMap<String, String> {
+    &GET_QUERY_PARAMETERS_ONCE
+}
+
+/// Returns the metadata within the caller's token, if present.
+pub fn token_metadata() -> &'static Option<String> {
+    &GET_TOKEN_METADATA_ONCE
+}
+
+/// Returns the invocation ID of the currently invoked function. This may be helpful to you
+/// if you want to connect a request ID to callers with the invocation that was used at that time.
+#[deprecated(since = "0.7.0", note = "Use `FunctionEnvironment` instead")]
+#[allow(unused)]
+pub fn invocation_id() -> String {
+    web_function_support::invocation_id()
+}

--- a/guest-web/src/wit.rs
+++ b/guest-web/src/wit.rs
@@ -1,0 +1,10 @@
+wit_bindgen::generate!({
+    world: "momento:web-function/web-function",
+    path: ["../wit/host/", "../wit/guest/"],
+    with: {
+        "momento:bytes/bytes@1.0.0": momento_functions_bytes::wit::momento::bytes::bytes,
+    },
+    default_bindings_module: "momento_functions_guest_web::wit",
+    export_macro_name: "export_web_function",
+    pub_export_macro: true,
+});

--- a/wit/guest/deps/spawn/guest-function-spawn.wit
+++ b/wit/guest/deps/spawn/guest-function-spawn.wit
@@ -1,0 +1,15 @@
+package momento:spawn-function@1.0.0;
+
+interface guest-function-spawn {
+    use momento:bytes/bytes@1.0.0.{data};
+
+    // A spawned function is triggered by an event. It does not have a return value.
+    //
+    // The ordering and concurrency semantics of a spawned function are not defined here;
+    // they are defined by the method in which the function is spawned.
+    spawned: func(payload: data);
+}
+
+world exports {
+    export guest-function-spawn;
+}

--- a/wit/guest/deps/web/guest-function-web.wit
+++ b/wit/guest/deps/web/guest-function-web.wit
@@ -1,0 +1,44 @@
+package momento:web-function@1.0.0;
+
+interface web-function-support {
+    // Call only once - these are taken from the host
+    headers: func() -> list<header>;
+    // Call only once - these are taken from the host
+    query-parameters: func() -> list<query-parameter>;
+    // Call only once - this is taken from the host
+    token-metadata: func() -> option<string>;
+    invocation-id: func() -> string;
+    http-method: func() -> string;
+    // Call only once - this is taken from the host
+    // This is the relative path under the function's base URL.
+    // If you call /my-function/foo/bar, this will return "foo/bar"
+    invocation-path: func() -> option<string>;
+
+    record header {
+        name: string,
+        value: string,
+    }
+
+    record query-parameter {
+        name: string,
+        value: string,
+    }
+}
+
+interface guest-function-web {
+    use momento:bytes/bytes@1.0.0.{data};
+    use web-function-support.{header};
+
+    invoke: func(request: data) -> response;
+
+    record response {
+        status: u16,
+        headers: list<header>,
+        body: data,
+    }
+}
+
+world web-function {
+    import web-function-support;
+    export guest-function-web;
+}

--- a/wit/guest/world.wit
+++ b/wit/guest/world.wit
@@ -1,0 +1,1 @@
+package momento:functions@2.0.0;

--- a/wit/host/deps/aws-auth/aws-auth.wit
+++ b/wit/host/deps/aws-auth/aws-auth.wit
@@ -1,0 +1,30 @@
+package momento:aws-auth@1.0.0;
+
+interface aws-auth {
+    /// Bare AWS credentials. Prefer other variants.
+    record credentials {
+        access-key-id: string,
+        secret-access-key: string,
+    }
+
+    /// Federated IAM role
+    record iam-role {
+        role-arn: string,
+    }
+
+    variant authorization {
+        hardcoded(credentials),
+        federated(iam-role),
+    }
+
+    variant auth-error {
+        unauthorized(string),
+    }
+
+    resource credentials-provider;
+    provider: func(authorization: authorization, region: string) -> result<credentials-provider, auth-error>;
+}
+
+world imports {
+    import aws-auth;
+}

--- a/wit/host/deps/aws-ddb/aws-ddb.wit
+++ b/wit/host/deps/aws-ddb/aws-ddb.wit
@@ -1,0 +1,104 @@
+package momento:aws-ddb@1.0.0;
+
+interface aws-ddb {
+    use momento:aws-auth/aws-auth@1.0.0.{credentials-provider};
+
+    variant ddb-error {
+        /// The request was not authorized.
+        unauthorized(string),
+        /// The request was malformed.
+        malformed(string),
+        /// The request failed for some other reason.
+        other(string),
+    }
+
+    record key-attribute {
+        name: string,
+        value: key-value,
+    }
+    variant key-value {
+        s(string),
+        n(string),
+        b(string),
+    }
+    record conditional {
+        expression: string,
+        expression-attribute-names: option<list<tuple<string, string>>>,
+        expression-attribute-values: option<item>,
+    }
+    variant return-consumed-capacity {
+        none,
+        total,
+        indexes,
+    }
+    variant return-values {
+        none,
+        all-old,
+    }
+    record consumed-capacity {
+        table-name: string,
+        capacity-units: option<f64>,
+        read-capacity-units: option<f64>,
+        write-capacity-units: option<f64>,
+        table: option<capacity>,
+        local-secondary-indexes: option<list<tuple<string, capacity>>>,
+        global-secondary-indexes: option<list<tuple<string, capacity>>>,
+    }
+    record capacity {
+        capacity-units: option<f64>,
+        read-capacity-units: option<f64>,
+        write-capacity-units: option<f64>,
+    }
+    variant item {
+        /// a json string of dynamodb-formatted json. Something like this:
+        /// {
+        ///   "profile_picture": { "B": "base64 string" },
+        ///   "is_valid": { "BOOL": true },
+        ///   "pictures": { "BS": ["base64 1", "base64 2"] },
+        ///   "friends": { "L": [{ "S": "bob" }, { "S": "alice" }] },
+        ///   "relationship": { "M": { "bob": {"S": "best friend"}, "alice": { "S": "second best friend" } } },
+        ///   "age": { "N": "23" },
+        ///   "favorite_birthdays": { "NS": ["17", "25"] },
+        ///   "children": { "NULL": true },
+        ///   "name": { "S": "arthur" },
+        ///   "friends": { "SS": ["bob", "alice"] }
+        /// }
+        json(string),
+    }
+
+    record put-item-request {
+        table-name: string,
+        item: item,
+        return-values: return-values,
+        return-consumed-capacity: return-consumed-capacity,
+        condition: option<conditional>,
+    }
+    record put-item-output {
+        attributes: option<item>,
+        consumed-capacity: option<consumed-capacity>,
+    }
+
+    record get-item-request {
+        table-name: string,
+        key: list<key-attribute>,
+        consistent-read: bool,
+        return-consumed-capacity: return-consumed-capacity,
+        projection-expression: option<string>,
+        expression-attribute-names: option<list<tuple<string, string>>>,
+    }
+    record get-item-output {
+        item: option<item>,
+        consumed-capacity: option<consumed-capacity>,
+    }
+
+    resource client {
+        constructor(credentials: borrow<credentials-provider>);
+        put-item: func(request: put-item-request) -> result<put-item-output, ddb-error>;
+        get-item: func(request: get-item-request) -> result<get-item-output, ddb-error>;
+    }
+}
+
+world imports {
+    import momento:aws-auth/aws-auth@1.0.0;
+    import aws-ddb;
+}

--- a/wit/host/deps/aws-lambda/aws-lambda.wit
+++ b/wit/host/deps/aws-lambda/aws-lambda.wit
@@ -1,0 +1,51 @@
+package momento:aws-lambda@1.0.0;
+
+interface aws-lambda {
+    use momento:aws-auth/aws-auth@1.0.0.{credentials-provider};
+    use momento:bytes/bytes@1.0.0.{data};
+
+    variant lambda-error {
+        /// The request was not authorized.
+        unauthorized(string),
+        /// The request was malformed.
+        malformed(string),
+        /// The request failed for some other reason.
+        other(string),
+    }
+
+    record invoke-request {
+        function-name: string,
+        qualifier: option<string>,
+        payload: option<data>,
+        invocation-type: invocation-type,
+    }
+    variant invocation-type {
+        request-response(invoke-synchronous-parameters),
+        event,
+        dry-run,
+    }
+    record invoke-synchronous-parameters {
+        log-type: option<log-type>,
+        client-context: option<string>,
+    }
+    variant log-type {
+        tail,
+    }
+    record invoke-output {
+        status-code: s32,
+        payload: option<data>,
+        log-result: option<string>,
+        executed-version: option<string>,
+    }
+
+    resource client {
+        constructor(credentials: borrow<credentials-provider>);
+        invoke: func(request: invoke-request) -> result<invoke-output, lambda-error>;
+    }
+}
+
+world imports {
+    import momento:aws-auth/aws-auth@1.0.0;
+    import momento:bytes/bytes@1.0.0;
+    import aws-lambda;
+}

--- a/wit/host/deps/aws-s3/aws-s3.wit
+++ b/wit/host/deps/aws-s3/aws-s3.wit
@@ -1,0 +1,51 @@
+package momento:aws-s3@1.0.0;
+
+interface aws-s3 {
+    use momento:aws-auth/aws-auth@1.0.0.{credentials-provider};
+    use momento:bytes/bytes@1.0.0.{data};
+
+    variant s3-error {
+      /// The request was not authorized.
+      unauthorized(string),
+      /// The request was malformed.
+      malformed(string),
+      /// The request failed for some other reason.
+      other(string),
+   }
+
+   record put-object-request {
+     bucket: string,
+     key: string,
+     body: data,
+   }
+
+   record put-object-output {
+     expiration: option<string>,
+     etag: option<string>,
+     version-id: option<string>,
+   }
+
+   record get-object-request {
+     bucket: string,
+     key: string,
+   }
+
+   record get-object-output {
+     body: option<data>,
+     etag: option<string>,
+     version-id: option<string>,
+     expiration: option<string>,
+   }
+
+   resource client {
+     constructor(credentials: borrow<credentials-provider>);
+     put: func(request: put-object-request) -> result<put-object-output, s3-error>;
+     get: func(request: get-object-request) -> result<get-object-output, s3-error>;
+   }
+}
+
+world imports {
+    import momento:aws-auth/aws-auth@1.0.0;
+    import momento:bytes/bytes@1.0.0;
+    import aws-s3;
+}

--- a/wit/host/deps/aws-secrets/aws-secrets.wit
+++ b/wit/host/deps/aws-secrets/aws-secrets.wit
@@ -1,0 +1,49 @@
+package momento:aws-secrets@1.0.0;
+
+interface aws-secrets {
+    use momento:aws-auth/aws-auth@1.0.0.{credentials-provider};
+
+    variant secrets-error {
+      /// The secret was not found
+      not-found,
+      /// The request was not authorized.
+      unauthorized(string),
+      /// The request was malformed.
+      malformed(string),
+      /// The request failed for some other reason.
+      other(string),
+    }
+
+    record get-secret-value-request {
+      secret-id: string,
+      version-id: option<string>,
+      version-stage: option<string>,
+    }
+
+    /// Secrets Manager will return either a (maybe) binary,
+    /// or a string. If both are returned, we'll return as bytes. See:
+    /// https://docs.aws.amazon.com/secretsmanager/latest/apireference/API_GetSecretValue.html
+    variant secret-value {
+      secret-bytes(list<u8>),
+      secret-string(string),
+    }
+
+    record get-secret-value-response {
+      arn: string,
+      created-date-epoch-seconds: u64,
+      name: string,
+      secret: secret-value, 
+      version-id: string,
+      version-stages: list<string>,
+    }
+
+    resource client {
+      constructor(credentials: borrow<credentials-provider>);
+      get-secret-value: func(request: get-secret-value-request) -> result<get-secret-value-response, secrets-error>;
+    }
+}
+
+world imports {
+    import momento:aws-auth/aws-auth@1.0.0;
+    import aws-secrets;
+}

--- a/wit/host/deps/bytes/bytes.wit
+++ b/wit/host/deps/bytes/bytes.wit
@@ -1,0 +1,36 @@
+package momento:bytes@1.0.0;
+
+interface bytes {
+    // for reading from the host
+    resource buffer {
+        // Get the number of bytes currently ready to be read.
+        //
+        // `read` can return this many bytes without blocking.
+        remaining: func() -> u32;
+
+        // Read up to `max-size` bytes from the body.
+        //
+        // It is an error to return more than `max-size` bytes.
+        //
+        // You have no guarantee that you'll get `max-size` bytes,
+        // but you will never get an empty list.
+        //
+        // Returns None if there is no more data.
+        read: func(max-size: u32) -> option<list<u8>>;
+
+        // Advance the read cursor by `size` bytes.
+        advance: func(size: u32);
+    }
+
+    // could be bytes or a buffer reference
+    variant data {
+        // use the remainder of this buffer
+        buffer(buffer),
+        // use these literal bytes
+        value(list<u8>),
+    }
+}
+
+world imports {
+    import bytes;
+}

--- a/wit/host/deps/cache-scalar/cache-scalar.wit
+++ b/wit/host/deps/cache-scalar/cache-scalar.wit
@@ -1,0 +1,23 @@
+package momento:cache-scalar@1.0.0;
+
+interface cache-scalar {
+
+    /// An error occurred while making the call.
+    variant error {
+        internal-error,
+        request-cancelled,
+        invalid-argument(string),
+        timeout,
+        permission-denied(string),
+        limit-exceeded(string),
+        failed-precondition(string),
+        not-found(string),
+    }
+
+    get: func(key: list<u8>) -> result<option<list<u8>>, error>;
+    set: func(key: list<u8>, value: list<u8>, ttl-milliseconds: u64) -> result<_, error>;
+}
+
+world imports {
+    import cache-scalar;
+}

--- a/wit/host/deps/http/http.wit
+++ b/wit/host/deps/http/http.wit
@@ -1,0 +1,78 @@
+package momento:http@1.0.0;
+
+interface http {
+    use momento:bytes/bytes@1.0.0.{data};
+
+    record request {
+        url: string,
+        verb: string,
+        headers: list<tuple<string, string>>,
+        body: data,
+        authorization: authorization,
+    }
+
+    /// A response returned from the server.
+    record response {
+        status: u16,
+        headers: list<tuple<string, string>>,
+        body: data,
+    }
+
+    record invalid-url {
+        url: string,
+        error: string,
+    }
+
+    record invalid-header-name {
+        header: string,
+        error: string,
+    }
+
+    record invalid-header-value {
+        value: string,
+        error: string,
+    }
+
+    /// An error while trying to make an http call.
+    variant error {
+        /// An internal error occurred within Momento.
+        internal-error,
+        /// An error while making a request. Under construction, may become structured errors in the future.
+        request-error(string),
+        /// The provided URL was not valid.
+        invalid-url(invalid-url),
+        /// A provided header name was not valid.
+        invalid-header-name(invalid-header-name),
+        /// A provided header value was not valid.
+        invalid-header-value(invalid-header-value),
+    }
+
+    variant authorization {
+        /// No special authorization behavior. You can still set an authorization header if you want.
+        none,
+        /// Explicit sigv4 signed request
+        aws-sigv4-secret(aws-sigv4-secret),
+        /// IAM role that Momento will federate into
+        federated(iam-role)
+    }
+
+    record aws-sigv4-secret {
+        access-key-id: string,
+        secret-access-key: string,
+        region: string,
+        service: string,
+    }
+
+    record iam-role {
+        role-arn: string,
+        service: string,
+    }
+
+    /// Send a web request
+    invoke: func(request: request) -> result<response, error>;
+}
+
+world imports {
+    import momento:bytes/bytes@1.0.0;
+    import http;
+}

--- a/wit/host/deps/log/log.wit
+++ b/wit/host/deps/log/log.wit
@@ -1,0 +1,55 @@
+package momento:log@1.0.0;
+
+interface logging {
+    variant log-configuration-error {
+        /// Contains the error message related to auth
+        auth(string),
+        // Other errors...
+    }
+
+    record topic-destination {
+        /// Required name to make service contract simpler
+        topic-name: string,
+    }
+
+    record cloudwatch-destination {
+        /// ARN for IAM role that a customer provides that Momento will federate into, giving us permissions to
+        /// to publish to their CW logs
+        iam-role-arn: string,
+        /// Name for the desired log group a customer wants us to publish to.
+        log-group-name: string,
+    }
+
+    variant destination {
+        topic(topic-destination),
+        cloudwatch(cloudwatch-destination),
+    }
+
+    enum log-level {
+        off,
+        debug,
+        info,
+        warn,
+        error,
+    }
+
+    record configure-logging-input {
+        log-level: log-level,
+        system-logs-level: log-level,
+        destination: destination
+    }
+    /// Configures logging for the function itself. Allows for multiple destinations, along with specified
+    /// system logging level a customer wants to capture.
+    /// E.g. "Send all logs + debug system logs to my topic, but only error-level system logs to my CW topic"
+    /// 
+    /// IMPORTANT: If capturing system logs interests you, be aware only the first list of inputs configured will
+    /// receive system logs captured before this is called. Any destinations added after will not have these system logs.
+    configure-logging: func(inputs: list<configure-logging-input>) -> result<_, log-configuration-error>;
+    /// Receives input (ideally through a custom-wrapped struct around the log!() macro) to feed to a
+    /// configured destination(s) (if exists)
+    log: func(input: string, level: log-level);
+}
+
+world imports {
+    import logging;
+}

--- a/wit/host/deps/spawn/spawn.wit
+++ b/wit/host/deps/spawn/spawn.wit
@@ -1,0 +1,20 @@
+package momento:spawn@1.0.0;
+
+interface spawn {
+    variant spawn-error {
+        /// The function does not exist.
+        function-not-found,
+        /// The function failed to spawn.
+        internal-error,
+        /// The function failed to spawn due to a limit error.
+        limit(string),
+    }
+
+    /// Invoke a Spawn Function by name with the given data.
+    /// Spawn Functions do not return a value to you - they are fire-and-forget.
+    spawn-function: func(name: string, data: list<u8>) -> result<_, spawn-error>;
+}
+
+world imports {
+    import spawn;
+}

--- a/wit/host/deps/token/token.wit
+++ b/wit/host/deps/token/token.wit
@@ -1,0 +1,40 @@
+package momento:token@1.0.0;
+
+interface token {
+  /// An error occurred while making the call.
+   variant token-error {
+        internal-error,
+        invalid-argument(string),
+        permission-denied(string),
+        limit-exceeded(string),
+    }
+
+  record expires {
+    /// How many seconds would you like the token to be valid for?
+    valid-for-seconds: u32,
+  }
+
+  record generate-disposable-token-response {
+    /// The new token
+    api-key: string,
+    /// The endpoint this token can be used against
+    endpoint: string,
+    /// Epoch seconds when the token expires
+    valid-until: u64,
+  }
+
+  /// Generate a token that has an expiry
+  generate-disposable-token: func(
+     /// Sets when the token will expire
+    expires: expires,
+    /// The permissions for the new token to be scoped with, serialized as a JSON string
+    permissions: string,
+    /// Optional string to be included inside the token. This field can also
+    /// be used to include a payload you know is signed within the token.
+    token-id: option<string>,
+  ) -> result<generate-disposable-token-response, token-error>;
+}
+
+world imports {
+    import token;
+}

--- a/wit/host/deps/topic/topic.wit
+++ b/wit/host/deps/topic/topic.wit
@@ -1,0 +1,25 @@
+package momento:topic@1.0.0;
+
+interface topic {
+    /// An error occurred while making the call.
+    variant error {
+        internal-error,
+        request-cancelled,
+        invalid-argument(string),
+        timeout,
+        permission-denied(string),
+        limit-exceeded(string),
+        failed-precondition(string),
+        not-found(string),
+    }
+
+    // Publish a string message to a topic
+    publish: func(topic: string, value: string) -> result<_, error>;
+
+    // Publish a bytes message to a topic
+    publish-bytes: func(topic: string, value: list<u8>) -> result<_, error>;
+}
+
+world imports {
+    import topic;
+}

--- a/wit/host/deps/valkey/valkey.wit
+++ b/wit/host/deps/valkey/valkey.wit
@@ -1,0 +1,64 @@
+package momento:valkey@1.0.0;
+
+// Momento host support for talking to valkey clusters from Functions
+interface valkey {
+    use momento:bytes/bytes@1.0.0.{data};
+
+    // An error from valkey
+    variant valkey-error {
+        // The request failed for some other reason.
+        other(string),
+    }
+
+    // A data tuple describing a command to be sent to valkey.
+    record command {
+        // The command name to execute
+        command: string,
+        // These are passed as you pass them. Mind your types and encodings,
+        // as correctness is between you and the valkey cluster.
+        arguments: list<data>,
+    }
+
+    // A stream of values from valkey
+    resource response-stream {
+        // The next result row of a query
+        //
+        // Returns None if there are no more rows
+        next: func() -> option<value>;
+    }
+
+    // A response from valkey
+    variant value {
+        // A nil response from the server.
+        nil,
+        // An integer response. Note that there are a few situations
+        // in which valkey actually returns a string for an integer.
+        int(s64),
+        // Arbitary binary data.
+        data(data),
+        // A bulk response of more data. This is generally used by valkey
+        // to express nested structures.
+        bulk(response-stream),
+        // An OK from valkey.
+        ok,
+        // Short, non-binary strings with minimal overhead
+        simple-string(string),
+        // Short, non-binary strings to describe an error
+        simple-error(string),
+    }
+
+    // A client to a valkey cluster
+    resource cluster-client {
+        // Execute a command against the cluster
+        // Only request/reply commands are supported here.
+        command: func(command: command) -> result<value, valkey-error>;
+    }
+
+    // Get a client to the cluster in your account with this name
+    get-managed-cluster-client: func(cluster-name: string) -> cluster-client;
+}
+
+world imports {
+    import momento:bytes/bytes@1.0.0;
+    import valkey;
+}

--- a/wit/host/world.wit
+++ b/wit/host/world.wit
@@ -1,0 +1,1 @@
+package momento:host@2.0.0;


### PR DESCRIPTION
this new set of libraries will work with off-wasm memory, and will
help reduce linker reference explosion. The separate interfaces are
their own worlds, and are referenced by dependents: You only link
to what you use. This means momento can iterate on interfaces that
are unrelated to users, and nobody is affected.
