### PR TITLE
fix: Use simple release please because of poor rust workspace support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.14.1"
+version = "0.14.1" # x-release-please-version
 authors = ["momentohq", "kvc0", "tylerburdsall"]
 repository = "https://github.com/momentohq/functions"
 edition = "2024"

--- a/bytes/Cargo.toml
+++ b/bytes/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "momento-functions-bytes"
 description = "off-guest buffer management"
-version = "0.14.1"
+version.workspace = true
 authors.workspace = true
 repository.workspace = true
 edition.workspace = true

--- a/guest-web/Cargo.toml
+++ b/guest-web/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "momento-functions-guest-web"
 description = "Guest bindings for Momento Web Functions"
-version = "0.14.1"
+version.workspace = true
 authors.workspace = true
 repository.workspace = true
 edition.workspace = true

--- a/momento-functions-host/Cargo.toml
+++ b/momento-functions-host/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "momento-functions-host"
 description = "Host interface support crate for Momento Functions"
-version = "0.14.1"
+version.workspace = true
 authors.workspace = true
 repository.workspace = true
 edition.workspace = true

--- a/momento-functions-log/Cargo.toml
+++ b/momento-functions-log/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "momento-functions-log"
 description = "Log adapter for momento Functions"
-version = "0.14.1"
+version.workspace = true
 authors.workspace = true
 repository.workspace = true
 edition.workspace = true

--- a/momento-functions-wit/Cargo.toml
+++ b/momento-functions-wit/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "momento-functions-wit"
 description = "Internal support crate for Momento Functions"
-version = "0.14.1"
+version.workspace = true
 authors.workspace = true
 repository.workspace = true
 edition.workspace = true

--- a/momento-functions/Cargo.toml
+++ b/momento-functions/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "momento-functions"
 description = "Support crate for Momento Functions"
-version = "0.14.1"
+version.workspace = true
 authors.workspace = true
 repository.workspace = true
 edition.workspace = true

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,7 +2,8 @@
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "packages": {
     ".": {
-      "release-type": "rust",
+      "release-type": "simple",
+      "extra-files": ["Cargo.toml"],
       "include-component-in-tag": false,
       "changelog-sections": [
         {


### PR DESCRIPTION
Switch to simple release-please because the rust profile doesn't support workspace versions:
https://github.com/googleapis/release-please/issues/2111
https://github.com/googleapis/release-please/issues/1896

We can move back to defining the sub Cargo.toml versions with `version.workspace = true` and rely on release-please to find and update the version in the base Cargo.toml.