### PR TITLE
feat: add v2 support for aws secrets manager

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -238,7 +238,7 @@ checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "momento-functions"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "itertools",
  "log",
@@ -253,7 +253,7 @@ dependencies = [
 
 [[package]]
 name = "momento-functions-aws-auth"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "thiserror",
  "wit-bindgen",
@@ -261,7 +261,17 @@ dependencies = [
 
 [[package]]
 name = "momento-functions-aws-s3"
-version = "0.21.0"
+version = "0.22.0"
+dependencies = [
+ "momento-functions-aws-auth",
+ "momento-functions-bytes",
+ "thiserror",
+ "wit-bindgen",
+]
+
+[[package]]
+name = "momento-functions-aws-secrets-manager"
+version = "0.22.0"
 dependencies = [
  "momento-functions-aws-auth",
  "momento-functions-bytes",
@@ -271,7 +281,7 @@ dependencies = [
 
 [[package]]
 name = "momento-functions-bytes"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -280,7 +290,7 @@ dependencies = [
 
 [[package]]
 name = "momento-functions-cache"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "momento-functions-bytes",
  "serde",
@@ -291,7 +301,7 @@ dependencies = [
 
 [[package]]
 name = "momento-functions-cache-list"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "momento-functions-bytes",
  "momento-functions-collections-common",
@@ -303,11 +313,11 @@ dependencies = [
 
 [[package]]
 name = "momento-functions-collections-common"
-version = "0.21.0"
+version = "0.22.0"
 
 [[package]]
 name = "momento-functions-guest-spawn"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "momento-functions-bytes",
  "serde",
@@ -317,7 +327,7 @@ dependencies = [
 
 [[package]]
 name = "momento-functions-guest-web"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "momento-functions-bytes",
  "serde",
@@ -327,7 +337,7 @@ dependencies = [
 
 [[package]]
 name = "momento-functions-host"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "base64",
  "log",
@@ -339,7 +349,7 @@ dependencies = [
 
 [[package]]
 name = "momento-functions-host-log"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "log",
  "thiserror",
@@ -349,7 +359,7 @@ dependencies = [
 
 [[package]]
 name = "momento-functions-http"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "momento-functions-bytes",
  "serde",
@@ -360,7 +370,7 @@ dependencies = [
 
 [[package]]
 name = "momento-functions-log"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "log",
  "momento-functions-host",
@@ -370,7 +380,7 @@ dependencies = [
 
 [[package]]
 name = "momento-functions-token"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -380,7 +390,7 @@ dependencies = [
 
 [[package]]
 name = "momento-functions-topic"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "momento-functions-bytes",
  "thiserror",
@@ -389,7 +399,7 @@ dependencies = [
 
 [[package]]
 name = "momento-functions-valkey"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "momento-functions-bytes",
  "thiserror",
@@ -398,7 +408,7 @@ dependencies = [
 
 [[package]]
 name = "momento-functions-wit"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "wit-bindgen",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ resolver = "2"
 members = [
     "aws-auth",
     "aws-s3",
+    "aws-secrets-manager",
     "bytes",
     "cache",
     "cache-list",
@@ -36,6 +37,7 @@ lto = true
 [workspace.dependencies]
 momento-functions-aws-auth    = { version = "0", path = "aws-auth" }
 momento-functions-aws-s3     = { version = "0", path = "aws-s3" }
+momento-functions-aws-secrets-manager = { version = "0", path = "aws-secrets-manager" }
 momento-functions-bytes      = { version = "0", path = "bytes" }
 momento-functions-collections-common = { version = "0", path = "collections-common" }
 momento-functions-guest-spawn = { version = "0", path = "guest-spawn" }

--- a/aws-secrets-manager/Cargo.toml
+++ b/aws-secrets-manager/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "momento-functions-aws-secrets-manager"
+description = "Host interfaces for AWS Secrets Manager interactions"
+version.workspace = true
+authors.workspace = true
+repository.workspace = true
+edition.workspace = true
+license.workspace = true
+readme.workspace = true
+keywords.workspace = true
+categories.workspace = true
+
+[dependencies]
+momento-functions-aws-auth = { workspace = true }
+momento-functions-bytes    = { workspace = true }
+thiserror                  = { workspace = true }
+wit-bindgen                = { workspace = true }

--- a/aws-secrets-manager/src/client.rs
+++ b/aws-secrets-manager/src/client.rs
@@ -1,0 +1,129 @@
+use std::time::Duration;
+
+use crate::wit::momento::aws_secrets::aws_secrets::{self as aws_secrets};
+use momento_functions_aws_auth::CredentialsProvider;
+use momento_functions_bytes::encoding::{Extract, ExtractError};
+
+/// Secrets Manager client for host interfaces.
+///
+/// This client uses Momento's host-provided AWS communication channel, which
+/// is kept hot at all times. When your Function has not run in several days or more,
+/// the channel is still hot and ready, keeping your Function invocations predictable
+/// even when your demand is unpredictable.
+pub struct SecretsManagerClient {
+    client: aws_secrets::Client,
+}
+
+/// Builder for a Secrets Manager `GetSecretValue` request.
+///
+/// Use `GetSecretValueRequest::new("your secret ID")` to construct what you need.
+pub struct GetSecretValueRequest {
+    secret_id: String,
+    version_id: Option<String>,
+    version_stage: Option<String>,
+}
+
+impl GetSecretValueRequest {
+    /// Create a new request builder for the specified secret.
+    ///
+    /// # Arguments
+    /// * `secret_id` - The name or ARN of the secret to retrieve.
+    pub fn new(secret_id: impl Into<String>) -> Self {
+        Self {
+            secret_id: secret_id.into(),
+            version_id: None,
+            version_stage: None,
+        }
+    }
+
+    /// Set the specific version of the secret to retrieve.
+    pub fn version_id(mut self, version_id: impl Into<String>) -> Self {
+        self.version_id = Some(version_id.into());
+        self
+    }
+
+    /// Set the version stage of the secret to retrieve (e.g., "AWSCURRENT", "AWSPENDING").
+    pub fn version_stage(mut self, version_stage: impl Into<String>) -> Self {
+        self.version_stage = Some(version_stage.into());
+        self
+    }
+}
+
+/// An error occurred while retrieving a secret from Secrets Manager.
+#[derive(Debug, thiserror::Error)]
+pub enum SecretsManagerGetSecretValueError<E>
+where
+    E: ExtractError,
+{
+    /// The value could not be extracted with the provided implementation.
+    #[error("Failed to extract value.")]
+    ExtractFailed {
+        /// The underlying extract error.
+        cause: E,
+    },
+    /// An error occurred when calling the host Secrets Manager interface.
+    #[error(transparent)]
+    SecretsManagerError(#[from] aws_secrets::SecretsError),
+}
+
+impl SecretsManagerClient {
+    /// Create a new Secrets Manager client.
+    pub fn new(credentials: &CredentialsProvider) -> Self {
+        Self {
+            client: aws_secrets::Client::new(credentials),
+        }
+    }
+
+    /// Get a secret value from AWS Secrets Manager.
+    ///
+    /// If you would like to avoid repeated calls to AWS Secrets Manager to save on latency,
+    /// pass a non-zero `allowed_staleness`. The secret is securely cached within the
+    /// Function's context and is only accessible by the Function itself. Once the cached
+    /// secret is older than `allowed_staleness`, the next call will go back to Secrets Manager.
+    ///
+    /// Pass `Duration::from_secs(0)` to always make the call to AWS.
+    ///
+    /// # Arguments
+    /// * `request` - The request to send to Secrets Manager.
+    /// * `allowed_staleness` - How long the cached secret may be reused before refetching.
+    pub fn get_secret_value<T: Extract>(
+        &self,
+        request: GetSecretValueRequest,
+        allowed_staleness: Duration,
+    ) -> Result<T, SecretsManagerGetSecretValueError<T::Error>> {
+        self.do_get_secret_value(request, allowed_staleness)
+    }
+
+    /// Like [`get_secret_value`](Self::get_secret_value), but always makes a request to
+    /// Secrets Manager for the latest value.
+    pub fn get_latest_secret_value<T: Extract>(
+        &self,
+        request: GetSecretValueRequest,
+    ) -> Result<T, SecretsManagerGetSecretValueError<T::Error>> {
+        self.do_get_secret_value(request, Duration::from_secs(0))
+    }
+
+    fn do_get_secret_value<T: Extract>(
+        &self,
+        request: GetSecretValueRequest,
+        allowed_staleness: Duration,
+    ) -> Result<T, SecretsManagerGetSecretValueError<T::Error>> {
+        let response = self
+            .client
+            .get_secret_value(&aws_secrets::GetSecretValueRequest {
+                secret_id: request.secret_id,
+                version_id: request.version_id,
+                version_stage: request.version_stage,
+                allowed_staleness_seconds: allowed_staleness.as_secs(),
+            })?;
+
+        // Normalize the secret to bytes regardless of which variant was returned.
+        let secret_bytes = match response.secret {
+            aws_secrets::SecretValue::SecretBytes(bytes) => bytes,
+            aws_secrets::SecretValue::SecretString(s) => s.into_bytes(),
+        };
+
+        T::extract(secret_bytes.into())
+            .map_err(|cause| SecretsManagerGetSecretValueError::ExtractFailed { cause })
+    }
+}

--- a/aws-secrets-manager/src/lib.rs
+++ b/aws-secrets-manager/src/lib.rs
@@ -1,0 +1,20 @@
+//! Host interfaces for working with AWS Secrets Manager.
+//!
+//! This crate provides a [`SecretsManagerClient`] for retrieving secrets from
+//! AWS Secrets Manager, using Momento's host-provided AWS communication channel.
+//!
+//! Functions use `wasm32-wasip2` as the target architecture.
+//! They use the [WIT](https://component-model.bytecodealliance.org/design/wit.html) [Component Model](https://component-model.bytecodealliance.org/)
+//! to describe the ABI.
+
+mod client;
+
+/// Internal module for WIT bindings.
+#[doc(hidden)]
+pub mod wit;
+
+pub use client::{GetSecretValueRequest, SecretsManagerClient, SecretsManagerGetSecretValueError};
+
+pub use momento_functions_aws_auth::{
+    AuthError, Authorization, Credentials, CredentialsProvider, IamRole, provider,
+};

--- a/aws-secrets-manager/src/wit.rs
+++ b/aws-secrets-manager/src/wit.rs
@@ -1,0 +1,7 @@
+wit_bindgen::generate!({
+    world: "momento:aws-secrets/imports",
+    path: [ "wit" ],
+    with: {
+        "momento:aws-auth/aws-auth@1.0.0": momento_functions_aws_auth::wit::momento::aws_auth::aws_auth,
+    },
+});

--- a/aws-secrets-manager/wit/aws-secrets.wit
+++ b/aws-secrets-manager/wit/aws-secrets.wit
@@ -33,7 +33,7 @@ interface aws-secrets {
       arn: string,
       created-date-epoch-seconds: u64,
       name: string,
-      secret: secret-value, 
+      secret: secret-value,
       version-id: string,
       version-stages: list<string>,
     }

--- a/aws-secrets-manager/wit/deps/aws-auth/aws-auth.wit
+++ b/aws-secrets-manager/wit/deps/aws-auth/aws-auth.wit
@@ -1,0 +1,30 @@
+package momento:aws-auth@1.0.0;
+
+interface aws-auth {
+    /// Bare AWS credentials. Prefer other variants.
+    record credentials {
+        access-key-id: string,
+        secret-access-key: string,
+    }
+
+    /// Federated IAM role
+    record iam-role {
+        role-arn: string,
+    }
+
+    variant authorization {
+        hardcoded(credentials),
+        federated(iam-role),
+    }
+
+    variant auth-error {
+        unauthorized(string),
+    }
+
+    resource credentials-provider;
+    provider: func(authorization: authorization, region: string) -> result<credentials-provider, auth-error>;
+}
+
+world imports {
+    import aws-auth;
+}


### PR DESCRIPTION
We can merge once host support rolls through, but this ports AWS Secrets Manager over to functions for v2
