### PR TITLE
docs: update README with new standard for Momento functions. adds new examples directory w/v2 implementations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,6 +121,301 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "example-cache-scalar"
+version = "0.0.0"
+dependencies = [
+ "log",
+ "momento-functions-bytes",
+ "momento-functions-cache",
+ "momento-functions-guest-web",
+ "momento-functions-host-log",
+]
+
+[[package]]
+name = "example-dynamodb-accelerator"
+version = "0.0.0"
+dependencies = [
+ "log",
+ "momento-functions-bytes",
+ "momento-functions-cache",
+ "momento-functions-guest-web",
+ "momento-functions-host-log",
+ "momento-functions-http",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "example-environment-variables"
+version = "0.0.0"
+dependencies = [
+ "itertools",
+ "momento-functions-bytes",
+ "momento-functions-guest-web",
+]
+
+[[package]]
+name = "example-fine-foods-embeddings"
+version = "0.0.0"
+dependencies = [
+ "itertools",
+ "log",
+ "momento-functions-bytes",
+ "momento-functions-guest-web",
+ "momento-functions-host-log",
+ "momento-functions-http",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "example-function-environment"
+version = "0.0.0"
+dependencies = [
+ "momento-functions-bytes",
+ "momento-functions-guest-web",
+]
+
+[[package]]
+name = "example-logging"
+version = "0.0.0"
+dependencies = [
+ "log",
+ "momento-functions-bytes",
+ "momento-functions-guest-web",
+ "momento-functions-host-log",
+ "serde",
+]
+
+[[package]]
+name = "example-logging-extended"
+version = "0.0.0"
+dependencies = [
+ "log",
+ "momento-functions-bytes",
+ "momento-functions-guest-web",
+ "momento-functions-host-log",
+ "serde",
+]
+
+[[package]]
+name = "example-reading-and-sending-headers"
+version = "0.0.0"
+dependencies = [
+ "itertools",
+ "momento-functions-bytes",
+ "momento-functions-guest-web",
+ "serde",
+]
+
+[[package]]
+name = "example-s3-get"
+version = "0.0.0"
+dependencies = [
+ "log",
+ "momento-functions-aws-auth",
+ "momento-functions-aws-s3",
+ "momento-functions-bytes",
+ "momento-functions-guest-web",
+ "momento-functions-host-log",
+ "serde",
+]
+
+[[package]]
+name = "example-s3-put"
+version = "0.0.0"
+dependencies = [
+ "log",
+ "momento-functions-aws-auth",
+ "momento-functions-aws-s3",
+ "momento-functions-bytes",
+ "momento-functions-guest-web",
+ "momento-functions-host-log",
+ "serde",
+]
+
+[[package]]
+name = "example-secrets-manager-get"
+version = "0.0.0"
+dependencies = [
+ "log",
+ "momento-functions-aws-auth",
+ "momento-functions-aws-secrets-manager",
+ "momento-functions-bytes",
+ "momento-functions-guest-web",
+ "momento-functions-host-log",
+ "serde",
+]
+
+[[package]]
+name = "example-spawn-function"
+version = "0.0.0"
+dependencies = [
+ "momento-functions-bytes",
+ "momento-functions-guest-spawn",
+]
+
+[[package]]
+name = "example-spawn-function-json"
+version = "0.0.0"
+dependencies = [
+ "momento-functions-bytes",
+ "momento-functions-guest-spawn",
+ "serde",
+]
+
+[[package]]
+name = "example-token-vending-machine"
+version = "0.0.0"
+dependencies = [
+ "log",
+ "momento-functions-bytes",
+ "momento-functions-guest-web",
+ "momento-functions-host-log",
+ "momento-functions-token",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "example-turbopuffer-index"
+version = "0.0.0"
+dependencies = [
+ "itertools",
+ "log",
+ "momento-functions-bytes",
+ "momento-functions-guest-web",
+ "momento-functions-host-log",
+ "momento-functions-http",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "example-turbopuffer-index-articles"
+version = "0.0.0"
+dependencies = [
+ "itertools",
+ "log",
+ "momento-functions-bytes",
+ "momento-functions-guest-web",
+ "momento-functions-host-log",
+ "momento-functions-http",
+ "serde",
+ "serde_json",
+ "tiktoken-rs",
+]
+
+[[package]]
+name = "example-turbopuffer-recommend-articles"
+version = "0.0.0"
+dependencies = [
+ "log",
+ "momento-functions-bytes",
+ "momento-functions-cache",
+ "momento-functions-guest-web",
+ "momento-functions-host-log",
+ "momento-functions-http",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "example-turbopuffer-search"
+version = "0.0.0"
+dependencies = [
+ "log",
+ "momento-functions-bytes",
+ "momento-functions-cache",
+ "momento-functions-guest-web",
+ "momento-functions-host-log",
+ "momento-functions-http",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "example-turbopuffer-search-articles"
+version = "0.0.0"
+dependencies = [
+ "log",
+ "momento-functions-bytes",
+ "momento-functions-cache",
+ "momento-functions-guest-web",
+ "momento-functions-host-log",
+ "momento-functions-http",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "example-valkey-cluster-vector-index"
+version = "0.0.0"
+dependencies = [
+ "log",
+ "momento-functions-bytes",
+ "momento-functions-guest-web",
+ "momento-functions-host-log",
+ "momento-functions-valkey",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "example-valkey-cluster-vector-search"
+version = "0.0.0"
+dependencies = [
+ "log",
+ "momento-functions-bytes",
+ "momento-functions-guest-web",
+ "momento-functions-host-log",
+ "momento-functions-http",
+ "momento-functions-valkey",
+ "serde",
+ "serde_json",
+ "sha2",
+]
+
+[[package]]
+name = "example-valkey-vector-embeddings"
+version = "0.0.0"
+dependencies = [
+ "log",
+ "momento-functions-bytes",
+ "momento-functions-guest-web",
+ "momento-functions-host-log",
+ "momento-functions-http",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "example-web-function"
+version = "0.0.0"
+dependencies = [
+ "momento-functions-bytes",
+ "momento-functions-guest-web",
+]
+
+[[package]]
+name = "example-web-function-json-greeter"
+version = "0.0.0"
+dependencies = [
+ "momento-functions-bytes",
+ "momento-functions-guest-web",
+ "serde",
+]
+
+[[package]]
+name = "example-web-function-token-metadata"
+version = "0.0.0"
+dependencies = [
+ "momento-functions-bytes",
+ "momento-functions-guest-web",
+ "serde",
+]
+
+[[package]]
 name = "fancy-regex"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -124,11 +124,9 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 name = "example-cache-scalar"
 version = "0.0.0"
 dependencies = [
- "log",
  "momento-functions-bytes",
  "momento-functions-cache",
  "momento-functions-guest-web",
- "momento-functions-host-log",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,33 @@ members = [
     "token",
     "topic",
     "valkey",
+
+    # V2 examples
+    "examples/cache-scalar",
+    "examples/dynamodb-accelerator",
+    "examples/environment-variables",
+    "examples/fine-foods-embeddings",
+    "examples/function-environment",
+    "examples/logging",
+    "examples/logging-extended",
+    "examples/reading-and-sending-headers",
+    "examples/s3-get",
+    "examples/s3-put",
+    "examples/secrets-manager-get",
+    "examples/spawn-function",
+    "examples/spawn-function-json",
+    "examples/token-vending-machine",
+    "examples/turbopuffer-index",
+    "examples/turbopuffer-index-articles",
+    "examples/turbopuffer-recommend-articles",
+    "examples/turbopuffer-search",
+    "examples/turbopuffer-search-articles",
+    "examples/valkey-cluster-vector-index",
+    "examples/valkey-cluster-vector-search",
+    "examples/valkey-vector-embeddings",
+    "examples/web-function",
+    "examples/web-function-json-greeter",
+    "examples/web-function-token-metadata",
 ]
 
 [workspace.package]
@@ -39,10 +66,15 @@ momento-functions-aws-auth    = { version = "0", path = "aws-auth" }
 momento-functions-aws-s3     = { version = "0", path = "aws-s3" }
 momento-functions-aws-secrets-manager = { version = "0", path = "aws-secrets-manager" }
 momento-functions-bytes      = { version = "0", path = "bytes" }
+momento-functions-cache      = { version = "0", path = "cache" }
 momento-functions-collections-common = { version = "0", path = "collections-common" }
 momento-functions-guest-spawn = { version = "0", path = "guest-spawn" }
+momento-functions-guest-web  = { version = "0", path = "guest-web" }
 momento-functions-host   = { version = "0", path = "momento-functions-host" }
+momento-functions-host-log = { version = "0", path = "log" }
+momento-functions-http   = { version = "0", path = "http" }
 momento-functions-log   = { version = "0", path = "momento-functions-log" }
+momento-functions-token  = { version = "0", path = "token" }
 momento-functions-valkey = { version = "0", path = "valkey" }
 momento-functions-wit   = { version = "0", path = "momento-functions-wit" }
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Functions run on Momento's service hosts, and offer a powerful scripting capabil
 
 This repository holds crates for Momento Functions guest code.
 
-To see some of what you can do with Functions, you can look at [the examples](./momento-functions/examples/).
+To see some of what you can do with Functions, you can look at [the examples](./examples/).
 
 ## Getting started
 
@@ -43,24 +43,62 @@ Add this to build the right kind of artifact:
 crate-type = ["cdylib"]
 ```
 
-Import the Functions support library and WIT library.
+Pull in only the crates you actually need. For a basic web function, the
+guest macro and the off-guest buffer crate are enough:
 
 ```toml
 [dependencies]
-momento-functions = { version = "0" }
-momento-functions-wit = { version = "0" }
+momento-functions-bytes     = { version = "0" }
+momento-functions-guest-web = { version = "0" }
 ```
+
+For a Spawn function, swap `guest-web` for `guest-spawn`. Other capabilities
+live in their own focused crates — add them as you go: `momento-functions-cache`,
+`momento-functions-http`, `momento-functions-token`, `momento-functions-topic`,
+`momento-functions-valkey`, `momento-functions-aws-s3`,
+`momento-functions-aws-secrets-manager`, `momento-functions-aws-auth`,
+`momento-functions-host-log`.
 
 ### Write a Function
 
 The simplest function is a pong response web function. You can put this in `lib.rs`.
 
 ```rust
-momento_functions::post!(ping);
-fn ping(_payload: Vec<u8>) -> &'static str {
+use momento_functions_bytes::Data;
+use momento_functions_guest_web::invoke;
+
+invoke!(ping);
+fn ping(_payload: Data) -> &'static str {
     "pong"
 }
 ```
+
+`Data` is a buffer that can stay on the host instead of being copied into your
+function's memory — useful when you're just passing bodies through. Call
+`Data::into_bytes()` when you actually need the bytes.
+
+For typed JSON in/out, swap the payload type for `momento_functions_bytes::encoding::Json<T>`:
+
+```rust
+use momento_functions_bytes::encoding::Json;
+use momento_functions_guest_web::invoke;
+
+#[derive(serde::Deserialize)]
+struct Request { name: String }
+
+#[derive(serde::Serialize)]
+struct Response { message: String }
+
+invoke!(greet);
+fn greet(Json(request): Json<Request>) -> Json<Response> {
+    Json(Response { message: format!("Hello, {}!", request.name) })
+}
+```
+
+For a portfolio of more substantial v2 Functions — cache, Valkey, HTTP
+integrations (Turbopuffer, OpenAI), AWS S3 / Secrets Manager, disposable
+token vending, structured logging, Spawn — see [`examples/`](./examples/).
+Each is its own minimal crate so you can copy a `Cargo.toml` as a starter.
 
 ### Build and deploy
 
@@ -109,7 +147,7 @@ curl \
 
 ### Going further
 
-From here, you should look at [the examples](./momento-functions/examples/). Momento Functions are a limited
+From here, you should look at [the examples](./examples/). Momento Functions are a limited
 environment, but the supported feature set is growing.
 
 ## Developing a Function

--- a/examples/cache-scalar/Cargo.toml
+++ b/examples/cache-scalar/Cargo.toml
@@ -11,6 +11,3 @@ crate-type = ["cdylib"]
 momento-functions-bytes     = { workspace = true }
 momento-functions-cache     = { workspace = true }
 momento-functions-guest-web = { workspace = true }
-momento-functions-host-log  = { workspace = true }
-
-log                         = { workspace = true }

--- a/examples/cache-scalar/Cargo.toml
+++ b/examples/cache-scalar/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "example-cache-scalar"
+version = "0.0.0"
+edition.workspace = true
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+momento-functions-bytes     = { workspace = true }
+momento-functions-cache     = { workspace = true }
+momento-functions-guest-web = { workspace = true }
+momento-functions-host-log  = { workspace = true }
+
+log                         = { workspace = true }

--- a/examples/cache-scalar/src/lib.rs
+++ b/examples/cache-scalar/src/lib.rs
@@ -1,85 +1,59 @@
 //! Demonstrates cache scalar operations: get, set, set_if, and delete.
-//! Subscribe to the function's topic to watch the emitted log lines.
 
 use std::time::Duration;
 
 use momento_functions_bytes::Data;
-use momento_functions_cache::{self as cache, ConditionalSetResult, SetIfCondition};
-use momento_functions_guest_web::{WebEnvironment, WebResult, invoke};
-use momento_functions_host_log::{LogDestination, configure_logs};
-
-fn describe<T>(result: &ConditionalSetResult<T>) -> &'static str {
-    match result {
-        ConditionalSetResult::Stored(_) => "Stored",
-        ConditionalSetResult::NotStored => "NotStored",
-    }
-}
+use momento_functions_cache::{self as cache, SetIfCondition};
+use momento_functions_guest_web::{WebResult, invoke};
 
 invoke!(demo);
 fn demo(_payload: Data) -> WebResult<&'static str> {
-    let env = WebEnvironment::load();
-    configure_logs([LogDestination::topic(env.function_name()).into()])?;
-
     let ttl = Duration::from_secs(60);
 
-    log::info!("Setting 'greeting' to 'Hello, World!'");
+    // Set 'greeting' to 'Hello, World!'
     cache::set("greeting", b"Hello, World!".to_vec(), ttl)?;
 
-    let value: Option<Vec<u8>> = cache::get("greeting")?;
-    log::info!(
-        "Got 'greeting': {:?}",
-        value.map(|v| String::from_utf8_lossy(&v).into_owned())
-    );
+    // Get 'greeting'
+    let _value: Option<Vec<u8>> = cache::get("greeting")?;
 
-    log::info!("Setting 'counter' to '0'");
+    // Set 'counter' to '0'
     cache::set("counter", b"0".to_vec(), ttl)?;
 
-    log::info!("Setting 'temp-data' to 'temporary'");
+    // Set 'temp-data' to 'temporary'
     cache::set("temp-data", b"temporary".to_vec(), ttl)?;
 
-    log::info!("Deleting 'temp-data'");
+    // Delete 'temp-data'
     cache::delete("temp-data")?;
 
-    let deleted_value: Option<Vec<u8>> = cache::get("temp-data")?;
-    log::info!("Got 'temp-data' after delete: {deleted_value:?}");
+    // Get 'temp-data' after delete (should be None)
+    let _deleted_value: Option<Vec<u8>> = cache::get("temp-data")?;
 
-    log::info!("set_if 'new-key' with condition Absent (key doesn't exist yet)");
-    let result = cache::set_if(
+    // set_if 'new-key' with condition Absent (key doesn't exist yet, will be Stored)
+    let _result = cache::set_if(
         "new-key",
         b"first-value".to_vec(),
         ttl,
         SetIfCondition::Absent,
     )?;
-    log::info!("Result: {}", describe(&result));
 
-    log::info!("set_if 'new-key' with condition Absent again (key now exists)");
-    let result = cache::set_if(
+    // set_if 'new-key' with condition Absent again (key now exists, will be NotStored)
+    let _result = cache::set_if(
         "new-key",
         b"second-value".to_vec(),
         ttl,
         SetIfCondition::Absent,
     )?;
-    log::info!(
-        "Result: {} (not stored because key already exists)",
-        describe(&result)
-    );
 
-    log::info!(
-        "set_if 'counter' to '1' with condition NotEqual('999') (will succeed, value is '0')"
-    );
-    let result = cache::set_if(
+    // set_if 'counter' to '1' with condition NotEqual('999') (will succeed, value is '0')
+    let _result = cache::set_if(
         "counter",
         b"1".to_vec(),
         ttl,
         SetIfCondition::NotEqual(b"999".to_vec().into()),
     )?;
-    log::info!("Result: {}", describe(&result));
 
-    let value: Option<Vec<u8>> = cache::get("counter")?;
-    log::info!(
-        "Final 'counter' value: {:?}",
-        value.map(|v| String::from_utf8_lossy(&v).into_owned())
-    );
+    // Get final 'counter' value
+    let _value: Option<Vec<u8>> = cache::get("counter")?;
 
-    Ok("Cache scalar demo completed! Check logs for details.")
+    Ok("Cache scalar demo completed!")
 }

--- a/examples/cache-scalar/src/lib.rs
+++ b/examples/cache-scalar/src/lib.rs
@@ -1,0 +1,85 @@
+//! Demonstrates cache scalar operations: get, set, set_if, and delete.
+//! Subscribe to the function's topic to watch the emitted log lines.
+
+use std::time::Duration;
+
+use momento_functions_bytes::Data;
+use momento_functions_cache::{self as cache, ConditionalSetResult, SetIfCondition};
+use momento_functions_guest_web::{WebEnvironment, WebResult, invoke};
+use momento_functions_host_log::{LogDestination, configure_logs};
+
+fn describe<T>(result: &ConditionalSetResult<T>) -> &'static str {
+    match result {
+        ConditionalSetResult::Stored(_) => "Stored",
+        ConditionalSetResult::NotStored => "NotStored",
+    }
+}
+
+invoke!(demo);
+fn demo(_payload: Data) -> WebResult<&'static str> {
+    let env = WebEnvironment::load();
+    configure_logs([LogDestination::topic(env.function_name()).into()])?;
+
+    let ttl = Duration::from_secs(60);
+
+    log::info!("Setting 'greeting' to 'Hello, World!'");
+    cache::set("greeting", b"Hello, World!".to_vec(), ttl)?;
+
+    let value: Option<Vec<u8>> = cache::get("greeting")?;
+    log::info!(
+        "Got 'greeting': {:?}",
+        value.map(|v| String::from_utf8_lossy(&v).into_owned())
+    );
+
+    log::info!("Setting 'counter' to '0'");
+    cache::set("counter", b"0".to_vec(), ttl)?;
+
+    log::info!("Setting 'temp-data' to 'temporary'");
+    cache::set("temp-data", b"temporary".to_vec(), ttl)?;
+
+    log::info!("Deleting 'temp-data'");
+    cache::delete("temp-data")?;
+
+    let deleted_value: Option<Vec<u8>> = cache::get("temp-data")?;
+    log::info!("Got 'temp-data' after delete: {deleted_value:?}");
+
+    log::info!("set_if 'new-key' with condition Absent (key doesn't exist yet)");
+    let result = cache::set_if(
+        "new-key",
+        b"first-value".to_vec(),
+        ttl,
+        SetIfCondition::Absent,
+    )?;
+    log::info!("Result: {}", describe(&result));
+
+    log::info!("set_if 'new-key' with condition Absent again (key now exists)");
+    let result = cache::set_if(
+        "new-key",
+        b"second-value".to_vec(),
+        ttl,
+        SetIfCondition::Absent,
+    )?;
+    log::info!(
+        "Result: {} (not stored because key already exists)",
+        describe(&result)
+    );
+
+    log::info!(
+        "set_if 'counter' to '1' with condition NotEqual('999') (will succeed, value is '0')"
+    );
+    let result = cache::set_if(
+        "counter",
+        b"1".to_vec(),
+        ttl,
+        SetIfCondition::NotEqual(b"999".to_vec().into()),
+    )?;
+    log::info!("Result: {}", describe(&result));
+
+    let value: Option<Vec<u8>> = cache::get("counter")?;
+    log::info!(
+        "Final 'counter' value: {:?}",
+        value.map(|v| String::from_utf8_lossy(&v).into_owned())
+    );
+
+    Ok("Cache scalar demo completed! Check logs for details.")
+}

--- a/examples/dynamodb-accelerator/Cargo.toml
+++ b/examples/dynamodb-accelerator/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "example-dynamodb-accelerator"
+version = "0.0.0"
+edition.workspace = true
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+momento-functions-bytes     = { workspace = true }
+momento-functions-cache     = { workspace = true }
+momento-functions-guest-web = { workspace = true }
+momento-functions-host-log  = { workspace = true }
+momento-functions-http      = { workspace = true }
+
+log                         = { workspace = true }
+serde                       = { workspace = true }
+serde_json                  = { workspace = true }

--- a/examples/dynamodb-accelerator/src/lib.rs
+++ b/examples/dynamodb-accelerator/src/lib.rs
@@ -1,0 +1,126 @@
+//! Caches DynamoDB GetItem responses by acting as a proxy in front of DynamoDB.
+//! Other DynamoDB API calls are passed straight through. The AWS SDK signs the
+//! request for `dynamodb.<region>.amazonaws.com`; the caller rewrites the URL
+//! to point at this Function and stashes the original target in the `x-uri`
+//! header (which is added *after* signing).
+
+use std::{collections::HashMap, time::Duration};
+
+use momento_functions_bytes::{
+    Data,
+    encoding::{Extract, Json},
+};
+use momento_functions_cache as cache;
+use momento_functions_guest_web::{WebEnvironment, WebError, WebResponse, WebResult, invoke};
+use momento_functions_host_log::{LogDestination, configure_logs};
+use momento_functions_http::{Request as HttpRequest, invoke as http_invoke};
+use serde::{Deserialize, Serialize};
+
+invoke!(accelerate_get_item);
+fn accelerate_get_item(body: Data) -> WebResult<WebResponse> {
+    setup_logging()?;
+
+    let env = WebEnvironment::load();
+    let headers = env.headers();
+    let body_bytes = body.into_bytes();
+
+    let action = require_header("X-Amz-Target", headers)?;
+    let proxy_uri = require_header("x-uri", headers)?;
+
+    let CachedResponse {
+        status,
+        headers: response_headers,
+        body: response_body,
+    } = match action.as_str() {
+        "DynamoDB_20120810.GetItem" => handle_get_item(body_bytes, headers, &proxy_uri)?,
+        other => handle_passthrough(other, body_bytes, headers, &proxy_uri)?,
+    };
+
+    let mut response = WebResponse::new().with_status(status);
+    for (k, v) in response_headers {
+        response = response.header(k, v);
+    }
+    Ok(response.with_body(response_body)?)
+}
+
+#[derive(Serialize, Deserialize)]
+struct CachedResponse {
+    status: u16,
+    headers: Vec<(String, String)>,
+    body: Vec<u8>,
+}
+
+fn handle_get_item(
+    body: Vec<u8>,
+    headers: &HashMap<String, String>,
+    proxy_uri: &str,
+) -> WebResult<CachedResponse> {
+    #[derive(Deserialize, Serialize, Debug)]
+    struct GetItemRequest {
+        #[serde(rename = "TableName")]
+        table_name: String,
+        #[serde(rename = "Key")]
+        key: serde_json::Value,
+    }
+
+    let Json(request) = Json::<GetItemRequest>::extract(Data::from(body.clone()))?;
+    log::info!("GetItem {request:?}");
+    let cache_key: String = serde_json::to_string(&request)?;
+
+    if let Some(Json(hit)) = cache::get::<Json<CachedResponse>>(cache_key.as_bytes().to_vec())? {
+        log::info!("Cache hit for {cache_key}");
+        return Ok(hit);
+    }
+
+    log::info!("Cache miss for {cache_key} -> {proxy_uri}");
+    let response = forward(proxy_uri, headers, body)?;
+    cache::set(
+        cache_key.as_bytes().to_vec(),
+        Json(&response),
+        Duration::from_secs(60),
+    )?;
+    Ok(response)
+}
+
+fn handle_passthrough(
+    action: &str,
+    body: Vec<u8>,
+    headers: &HashMap<String, String>,
+    proxy_uri: &str,
+) -> WebResult<CachedResponse> {
+    log::info!("other action: {action} -> {proxy_uri}");
+    forward(proxy_uri, headers, body)
+}
+
+fn forward(
+    proxy_uri: &str,
+    headers: &HashMap<String, String>,
+    body: Vec<u8>,
+) -> WebResult<CachedResponse> {
+    let mut request = HttpRequest::new(proxy_uri, "POST").with_body(body);
+    for (name, value) in headers {
+        request = request.with_header(name.clone(), value.clone());
+    }
+    let response = http_invoke(request)?;
+    Ok(CachedResponse {
+        status: response.status,
+        headers: response.headers,
+        body: response.body.into_bytes(),
+    })
+}
+
+fn require_header(header: &str, headers: &HashMap<String, String>) -> WebResult<String> {
+    headers
+        .iter()
+        .find_map(|(name, value)| name.eq_ignore_ascii_case(header).then(|| value.to_string()))
+        .ok_or_else(|| {
+            log::error!("Missing {header} header");
+            WebError::message(format!("Missing {header} header"))
+        })
+}
+
+fn setup_logging() -> WebResult<()> {
+    let env = WebEnvironment::load();
+    configure_logs([LogDestination::topic(env.function_name()).into()])?;
+    Ok(())
+}

--- a/examples/environment-variables/Cargo.toml
+++ b/examples/environment-variables/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "example-environment-variables"
+version = "0.0.0"
+edition.workspace = true
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+momento-functions-bytes     = { workspace = true }
+momento-functions-guest-web = { workspace = true }
+
+itertools                   = { workspace = true }

--- a/examples/environment-variables/src/lib.rs
+++ b/examples/environment-variables/src/lib.rs
@@ -1,0 +1,8 @@
+use itertools::Itertools;
+use momento_functions_bytes::Data;
+use momento_functions_guest_web::invoke;
+
+invoke!(env);
+fn env(_payload: Data) -> String {
+    std::env::vars().map(|(k, v)| format!("{k}={v}")).join("\n")
+}

--- a/examples/fine-foods-embeddings/Cargo.toml
+++ b/examples/fine-foods-embeddings/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "example-fine-foods-embeddings"
+version = "0.0.0"
+edition.workspace = true
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+momento-functions-bytes     = { workspace = true }
+momento-functions-guest-web = { workspace = true }
+momento-functions-host-log  = { workspace = true }
+momento-functions-http      = { workspace = true }
+
+itertools                   = { workspace = true }
+log                         = { workspace = true }
+serde                       = { workspace = true }
+serde_json                  = { workspace = true }

--- a/examples/fine-foods-embeddings/src/lib.rs
+++ b/examples/fine-foods-embeddings/src/lib.rs
@@ -1,0 +1,154 @@
+//! Generates OpenAI embeddings for the Amazon fine-foods reviews dataset.
+//! Pre-process the CSV into JSON files of ~12MB and POST each chunk to this
+//! Function. The dataset is at:
+//! https://www.kaggle.com/datasets/snap/amazon-fine-food-reviews?resource=download
+//!
+//! ```bash
+//! any-json Reviews.csv Reviews.json
+//! jq -c '_nwise(10000)' Reviews.json > reviews-chunked.json
+//! split -l 1 -da 3 reviews-chunked.json reviews-batchembed.json
+//!
+//! for file in $(ls reviews-batchembed.json*); do
+//!     curl $momento/functions/my-cache/fine-foods-embeddings \
+//!         -H "authorization: $momento_api_key" \
+//!         -XPOST --data-binary @$file > reviews-index-$i.json
+//! done
+//! ```
+
+use itertools::Itertools;
+use momento_functions_bytes::encoding::{Extract, Json};
+use momento_functions_guest_web::{WebEnvironment, WebResponse, WebResult, invoke};
+use momento_functions_host_log::{LogDestination, configure_logs};
+use momento_functions_http::{Request as HttpRequest, invoke as http_invoke};
+use serde::{Deserialize, Serialize};
+
+#[derive(Deserialize, Debug)]
+struct DocumentInput {
+    #[serde(alias = "Id")]
+    id: String,
+    #[serde(alias = "ProductId")]
+    product_id: String,
+    #[serde(alias = "UserId")]
+    user_id: String,
+    #[serde(alias = "ProfileName")]
+    profile_name: String,
+    #[serde(alias = "HelpfulnessNumerator", deserialize_with = "parse_i32")]
+    helpfulness_numerator: i32,
+    #[serde(alias = "HelpfulnessDenominator", deserialize_with = "parse_i32")]
+    helpfulness_denominator: i32,
+    #[serde(alias = "Score", deserialize_with = "parse_i32")]
+    score: i32,
+    #[serde(alias = "Time", deserialize_with = "parse_u32")]
+    time: u32,
+    #[serde(alias = "Summary")]
+    summary: String,
+    #[serde(alias = "Text")]
+    text: String,
+}
+
+fn parse_i32<'de, D>(deserializer: D) -> Result<i32, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let buf = String::deserialize(deserializer)?;
+    buf.parse().map_err(serde::de::Error::custom)
+}
+
+fn parse_u32<'de, D>(deserializer: D) -> Result<u32, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let buf = String::deserialize(deserializer)?;
+    buf.parse().map_err(serde::de::Error::custom)
+}
+
+#[derive(Serialize, Debug)]
+struct DocumentOutput {
+    embedding: Vec<f32>,
+    id: String,
+    product_id: String,
+    user_id: String,
+    profile_name: String,
+    helpfulness_numerator: i32,
+    helpfulness_denominator: i32,
+    score: i32,
+    time: u32,
+    summary: String,
+    text: String,
+}
+
+invoke!(generate_embeddings);
+fn generate_embeddings(Json(documents): Json<Vec<DocumentInput>>) -> WebResult<WebResponse> {
+    setup_logging()?;
+
+    log::debug!("getting embeddings for {} documents", documents.len());
+    let mut response = Vec::with_capacity(documents.len());
+
+    for chunk in &documents.into_iter().chunks(2000) {
+        let chunk: Vec<_> = chunk.collect();
+        let embeddings = get_embeddings(chunk.iter().map(|d| d.text.clone()).collect())?;
+        response.extend(chunk.into_iter().zip(embeddings).map(|(input, embedding)| {
+            DocumentOutput {
+                embedding,
+                id: input.id,
+                product_id: input.product_id,
+                user_id: input.user_id,
+                profile_name: input.profile_name,
+                helpfulness_numerator: input.helpfulness_numerator,
+                helpfulness_denominator: input.helpfulness_denominator,
+                score: input.score,
+                time: input.time,
+                summary: input.summary,
+                text: input.text,
+            }
+        }));
+    }
+
+    Ok(WebResponse::new()
+        .with_status(200)
+        .with_body(Json(response))?)
+}
+
+fn setup_logging() -> WebResult<()> {
+    let env = WebEnvironment::load();
+    configure_logs([LogDestination::topic(env.function_name()).into()])?;
+    Ok(())
+}
+
+fn get_embeddings(mut documents: Vec<String>) -> WebResult<Vec<Vec<f32>>> {
+    log::debug!("getting embeddings for document with content: {documents:?}");
+    for document in &mut documents {
+        if document.contains('\n') {
+            *document = document.replace('\n', " ");
+        }
+    }
+
+    let openai_api_key = std::env::var("OPENAI_API_KEY").unwrap_or_default();
+    let response = http_invoke(
+        HttpRequest::new("https://api.openai.com/v1/embeddings", "POST")
+            .with_header("authorization", format!("Bearer {openai_api_key}"))
+            .with_header("content-type", "application/json")
+            .with_body(
+                serde_json::json!({
+                    "model": "text-embedding-3-small",
+                    "encoding_format": "float",
+                    "input": documents,
+                })
+                .to_string(),
+            ),
+    )?;
+    log::debug!("OpenAI response status: {}", response.status);
+
+    #[derive(Deserialize, Debug)]
+    struct EmbeddingResponse {
+        data: Vec<EmbeddingData>,
+    }
+    #[derive(Deserialize, Serialize, Debug)]
+    struct EmbeddingData {
+        embedding: Vec<f32>,
+        index: usize,
+    }
+    let Json(EmbeddingResponse { mut data }) = Json::<EmbeddingResponse>::extract(response.body)?;
+    data.sort_by_key(|d| d.index);
+    Ok(data.into_iter().map(|d| d.embedding).collect())
+}

--- a/examples/function-environment/Cargo.toml
+++ b/examples/function-environment/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "example-function-environment"
+version = "0.0.0"
+edition.workspace = true
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+momento-functions-bytes     = { workspace = true }
+momento-functions-guest-web = { workspace = true }

--- a/examples/function-environment/src/lib.rs
+++ b/examples/function-environment/src/lib.rs
@@ -1,0 +1,26 @@
+use momento_functions_bytes::Data;
+use momento_functions_guest_web::{WebEnvironment, invoke};
+
+invoke!(function_environment);
+fn function_environment(_payload: Data) -> String {
+    let env = WebEnvironment::load();
+    format!(
+        r#"Cache: {},
+Function: {},
+Invocation ID: {},
+Query parameters: {},
+HTTP method: {}
+HTTP path: {}
+"#,
+        env.cache_name(),
+        env.function_name(),
+        env.invocation_id(),
+        env.query_parameters()
+            .iter()
+            .map(|(k, v)| format!("{k}={v}"))
+            .collect::<Vec<_>>()
+            .join(", "),
+        env.http_method(),
+        env.http_path()
+    )
+}

--- a/examples/logging-extended/Cargo.toml
+++ b/examples/logging-extended/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "example-logging-extended"
+version = "0.0.0"
+edition.workspace = true
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+momento-functions-bytes     = { workspace = true }
+momento-functions-guest-web = { workspace = true }
+momento-functions-host-log  = { workspace = true }
+
+log                         = { workspace = true }
+serde                       = { workspace = true }

--- a/examples/logging-extended/src/lib.rs
+++ b/examples/logging-extended/src/lib.rs
@@ -1,0 +1,51 @@
+//! Demonstrates more advanced log configuration: one system-only topic, one
+//! function-log topic filtered at DEBUG, and a CloudWatch log group. Assumes
+//! an IAM role has already been configured — reach out to
+//! `support@momentohq.com` for assistance with IAM role setup.
+
+use momento_functions_bytes::encoding::Json;
+use momento_functions_guest_web::{WebEnvironment, WebResult, invoke};
+use momento_functions_host_log::{LogConfiguration, LogDestination, configure_logs};
+
+#[derive(serde::Deserialize, Debug)]
+struct Request {
+    iam_role_arn: String,
+    log_group_name: String,
+    name: String,
+}
+
+#[derive(serde::Serialize)]
+struct Response {
+    message: String,
+}
+
+invoke!(greet);
+fn greet(Json(request): Json<Request>) -> WebResult<Json<Response>> {
+    let env = WebEnvironment::load();
+    configure_logs([
+        // Dedicated topic that only receives system logs.
+        LogConfiguration::new(LogDestination::topic(format!(
+            "{}-system-logs",
+            env.function_name()
+        )))
+        .with_log_level(log::LevelFilter::Off)
+        .with_system_log_level(log::LevelFilter::Debug),
+        // Standard topic for DEBUG+ application logs and ERROR+ system logs.
+        LogConfiguration::new(LogDestination::topic(env.function_name()))
+            .with_log_level(log::LevelFilter::Debug)
+            .with_system_log_level(log::LevelFilter::Error),
+        // CloudWatch destination at the default INFO level for both streams.
+        LogConfiguration::new(LogDestination::cloudwatch(
+            request.iam_role_arn.clone(),
+            request.log_group_name.clone(),
+        )),
+    ])?;
+
+    log::debug!("Logging a debug message");
+    log::info!("Received request: {request:?}");
+    log::error!("Logging an error message");
+
+    Ok(Json(Response {
+        message: format!("Hello, {}!", request.name),
+    }))
+}

--- a/examples/logging/Cargo.toml
+++ b/examples/logging/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "example-logging"
+version = "0.0.0"
+edition.workspace = true
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+momento-functions-bytes     = { workspace = true }
+momento-functions-guest-web = { workspace = true }
+momento-functions-host-log  = { workspace = true }
+
+log                         = { workspace = true }
+serde                       = { workspace = true }

--- a/examples/logging/src/lib.rs
+++ b/examples/logging/src/lib.rs
@@ -1,0 +1,27 @@
+use momento_functions_bytes::encoding::Json;
+use momento_functions_guest_web::{WebEnvironment, WebResult, invoke};
+use momento_functions_host_log::{LogDestination, configure_logs};
+
+#[derive(serde::Deserialize, Debug)]
+struct Request {
+    name: String,
+}
+
+#[derive(serde::Serialize)]
+struct Response {
+    message: String,
+}
+
+invoke!(greet);
+fn greet(Json(request): Json<Request>) -> WebResult<Json<Response>> {
+    let env = WebEnvironment::load();
+    // Simple topic destination. Uses the default log level of INFO for both
+    // system and function logs.
+    configure_logs([LogDestination::topic(env.function_name()).into()])?;
+
+    log::info!("Received request: {request:?}");
+
+    Ok(Json(Response {
+        message: format!("Hello, {}!", request.name),
+    }))
+}

--- a/examples/reading-and-sending-headers/Cargo.toml
+++ b/examples/reading-and-sending-headers/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "example-reading-and-sending-headers"
+version = "0.0.0"
+edition.workspace = true
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+momento-functions-bytes     = { workspace = true }
+momento-functions-guest-web = { workspace = true }
+
+itertools                   = { workspace = true }
+serde                       = { workspace = true }

--- a/examples/reading-and-sending-headers/src/lib.rs
+++ b/examples/reading-and-sending-headers/src/lib.rs
@@ -1,0 +1,26 @@
+use std::collections::HashMap;
+
+use itertools::Itertools;
+use momento_functions_bytes::encoding::Json;
+use momento_functions_guest_web::{WebEnvironment, WebResponse, WebResult, invoke};
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize)]
+struct Request {
+    headers_to_send_back: HashMap<String, String>,
+}
+
+invoke!(headers_example);
+fn headers_example(Json(request): Json<Request>) -> WebResult<WebResponse> {
+    let headers = WebEnvironment::load().headers();
+    // Don't expose secrets!
+    let headers_to_return = headers
+        .iter()
+        .filter(|(k, _)| *k != "authorization")
+        .map(|(k, v)| format!("'{k}'='{v}'"))
+        .join(" | ");
+    Ok(WebResponse::new()
+        .with_status(200)
+        .with_headers(request.headers_to_send_back.into_iter().collect())
+        .with_body(format!("You sent this with headers: {headers_to_return}"))?)
+}

--- a/examples/s3-get/Cargo.toml
+++ b/examples/s3-get/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "example-s3-get"
+version = "0.0.0"
+edition.workspace = true
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+momento-functions-aws-auth  = { workspace = true }
+momento-functions-aws-s3    = { workspace = true }
+momento-functions-bytes     = { workspace = true }
+momento-functions-guest-web = { workspace = true }
+momento-functions-host-log  = { workspace = true }
+
+log                         = { workspace = true }
+serde                       = { workspace = true }

--- a/examples/s3-get/src/lib.rs
+++ b/examples/s3-get/src/lib.rs
@@ -1,0 +1,72 @@
+use momento_functions_aws_auth::{Authorization, IamRole, provider};
+use momento_functions_aws_s3::S3Client;
+use momento_functions_bytes::encoding::Json;
+use momento_functions_guest_web::{WebEnvironment, WebResponse, WebResult, invoke};
+use momento_functions_host_log::{LogDestination, configure_logs};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Deserialize)]
+struct Request {
+    role_arn: String,
+    bucket: String,
+    key: String,
+}
+
+#[derive(Debug, Serialize)]
+struct Response {
+    message: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct MyStructure {
+    a_number: u32,
+    a_string: String,
+}
+
+invoke!(s3_get);
+fn s3_get(Json(request): Json<Request>) -> WebResult<WebResponse> {
+    let env = WebEnvironment::load();
+    configure_logs([LogDestination::topic(env.function_name()).into()])?;
+
+    let credentials = provider(
+        &Authorization::Federated(IamRole {
+            role_arn: request.role_arn,
+        }),
+        "us-west-2",
+    )?;
+    let client = S3Client::new(&credentials);
+
+    log::info!(
+        "getting object from s3, bucket {}, key {}",
+        &request.bucket,
+        &request.key
+    );
+    let response: MyStructure = match client.get(&request.bucket, &request.key) {
+        Ok(Some(Json(r))) => r,
+        Ok(None) => {
+            return Ok(WebResponse::new()
+                .with_status(404)
+                .with_body(Json(Response {
+                    message: "Not found".to_string(),
+                }))?);
+        }
+        Err(e) => {
+            return Ok(WebResponse::new()
+                .with_status(500)
+                .with_body(Json(Response {
+                    message: format!("Failed to get object from S3: {e:?}"),
+                }))?);
+        }
+    };
+
+    log::info!(
+        "found response with a_number: {}, a_string: {}",
+        response.a_number,
+        response.a_string
+    );
+    Ok(WebResponse::new()
+        .with_status(200)
+        .with_body(Json(Response {
+            message: format!("Found: {response:?}"),
+        }))?)
+}

--- a/examples/s3-put/Cargo.toml
+++ b/examples/s3-put/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "example-s3-put"
+version = "0.0.0"
+edition.workspace = true
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+momento-functions-aws-auth  = { workspace = true }
+momento-functions-aws-s3    = { workspace = true }
+momento-functions-bytes     = { workspace = true }
+momento-functions-guest-web = { workspace = true }
+momento-functions-host-log  = { workspace = true }
+
+log                         = { workspace = true }
+serde                       = { workspace = true }

--- a/examples/s3-put/src/lib.rs
+++ b/examples/s3-put/src/lib.rs
@@ -1,0 +1,67 @@
+use momento_functions_aws_auth::{Authorization, IamRole, provider};
+use momento_functions_aws_s3::S3Client;
+use momento_functions_bytes::encoding::Json;
+use momento_functions_guest_web::{WebEnvironment, WebResponse, WebResult, invoke};
+use momento_functions_host_log::{LogDestination, configure_logs};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Deserialize)]
+struct Request {
+    role_arn: String,
+    bucket: String,
+    key: String,
+    value: String,
+}
+
+#[derive(Debug, Serialize)]
+struct Response {
+    message: String,
+}
+
+#[derive(Debug, Serialize)]
+struct MyStructure {
+    a_number: u32,
+    a_string: String,
+}
+
+invoke!(s3_put);
+fn s3_put(Json(request): Json<Request>) -> WebResult<WebResponse> {
+    let env = WebEnvironment::load();
+    configure_logs([LogDestination::topic(env.function_name()).into()])?;
+
+    let credentials = provider(
+        &Authorization::Federated(IamRole {
+            role_arn: request.role_arn,
+        }),
+        "us-west-2",
+    )?;
+    let client = S3Client::new(&credentials);
+
+    log::info!(
+        "putting object to s3, bucket: {}; key {}; size of value {}",
+        &request.bucket,
+        &request.key,
+        &request.value.len()
+    );
+
+    if let Err(e) = client.put(
+        &request.bucket,
+        &request.key,
+        Json(MyStructure {
+            a_number: 42,
+            a_string: request.value,
+        }),
+    ) {
+        return Ok(WebResponse::new()
+            .with_status(500)
+            .with_body(Json(Response {
+                message: format!("Failed to put object {e:?}"),
+            }))?);
+    }
+
+    Ok(WebResponse::new()
+        .with_status(200)
+        .with_body(Json(Response {
+            message: "Successfully put object".to_string(),
+        }))?)
+}

--- a/examples/secrets-manager-get/Cargo.toml
+++ b/examples/secrets-manager-get/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "example-secrets-manager-get"
+version = "0.0.0"
+edition.workspace = true
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+momento-functions-aws-auth             = { workspace = true }
+momento-functions-aws-secrets-manager  = { workspace = true }
+momento-functions-bytes                = { workspace = true }
+momento-functions-guest-web            = { workspace = true }
+momento-functions-host-log             = { workspace = true }
+
+log                                    = { workspace = true }
+serde                                  = { workspace = true }

--- a/examples/secrets-manager-get/src/lib.rs
+++ b/examples/secrets-manager-get/src/lib.rs
@@ -1,0 +1,89 @@
+//! Demonstrates fetching a secret from AWS Secrets Manager via Momento's
+//! host-managed AWS channel. Returns only the length of the secret to avoid
+//! leaking the value.
+//!
+//! Imagine the secret has been stored as:
+//! ```json
+//! { "token": "my super secret JWT for my service" }
+//! ```
+
+use std::time::Duration;
+
+use momento_functions_aws_auth::{Authorization, IamRole, provider};
+use momento_functions_aws_secrets_manager::{GetSecretValueRequest, SecretsManagerClient};
+use momento_functions_bytes::encoding::Json;
+use momento_functions_guest_web::{WebResponse, WebResult, invoke};
+use momento_functions_host_log::{LogConfiguration, LogDestination, configure_logs};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Deserialize)]
+struct Request {
+    secret_name: String,
+}
+
+#[derive(Debug, Serialize)]
+struct Response {
+    message: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct MySecret {
+    pub token: String,
+}
+
+invoke!(secrets_manager_get);
+fn secrets_manager_get(Json(request): Json<Request>) -> WebResult<WebResponse> {
+    configure_logs([
+        LogConfiguration::new(LogDestination::topic("secrets-manager-get"))
+            .with_log_level(log::LevelFilter::Debug),
+    ])?;
+
+    // Provide the IAM role ARN that Momento will federate into to read the secret.
+    let credentials = provider(
+        &Authorization::Federated(IamRole {
+            role_arn: "<name of your role ARN>".to_string(),
+        }),
+        "us-west-2",
+    )?;
+
+    let client = SecretsManagerClient::new(&credentials);
+
+    // How long the in-context secret cache may be reused before refetching.
+    let allowed_staleness = Duration::from_secs(5 * 60);
+
+    log::info!("Retrieving secret: {}", &request.secret_name);
+
+    let Json(secret): Json<MySecret> = match client.get_secret_value(
+        GetSecretValueRequest::new(&request.secret_name),
+        allowed_staleness,
+    ) {
+        Ok(s) => s,
+        Err(e) => {
+            log::error!("Failed to retrieve secret: {e:?}");
+            return Ok(WebResponse::new()
+                .with_status(500)
+                .with_body(Json(Response {
+                    message: format!("Failed to retrieve secret: {e:?}"),
+                }))?);
+        }
+    };
+
+    if secret.token.is_empty() {
+        log::error!("The token should have had a value, but we got an empty string instead");
+        return Ok(WebResponse::new()
+            .with_status(500)
+            .with_body(Json(Response {
+                message: "Failed to retrieve secret: the value returned was not valid".to_string(),
+            }))?);
+    }
+
+    log::info!("Successfully retrieved secret");
+    Ok(WebResponse::new()
+        .with_status(200)
+        .with_body(Json(Response {
+            message: format!(
+                "Secret retrieved successfully! Secret length: {}",
+                secret.token.len()
+            ),
+        }))?)
+}

--- a/examples/spawn-function-json/Cargo.toml
+++ b/examples/spawn-function-json/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "example-spawn-function-json"
+version = "0.0.0"
+edition.workspace = true
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+momento-functions-bytes       = { workspace = true }
+momento-functions-guest-spawn = { workspace = true }
+
+serde                         = { workspace = true }

--- a/examples/spawn-function-json/src/lib.rs
+++ b/examples/spawn-function-json/src/lib.rs
@@ -1,0 +1,10 @@
+use momento_functions_bytes::encoding::Json;
+use momento_functions_guest_spawn::spawn;
+
+#[derive(serde::Deserialize)]
+struct Request {
+    _name: String,
+}
+
+spawn!(spawned);
+fn spawned(Json(_payload): Json<Request>) {}

--- a/examples/spawn-function/Cargo.toml
+++ b/examples/spawn-function/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "example-spawn-function"
+version = "0.0.0"
+edition.workspace = true
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+momento-functions-bytes       = { workspace = true }
+momento-functions-guest-spawn = { workspace = true }

--- a/examples/spawn-function/src/lib.rs
+++ b/examples/spawn-function/src/lib.rs
@@ -1,0 +1,5 @@
+use momento_functions_bytes::Data;
+use momento_functions_guest_spawn::spawn;
+
+spawn!(spawned);
+fn spawned(_payload: Data) {}

--- a/examples/token-vending-machine/Cargo.toml
+++ b/examples/token-vending-machine/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "example-token-vending-machine"
+version = "0.0.0"
+edition.workspace = true
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+momento-functions-bytes     = { workspace = true }
+momento-functions-guest-web = { workspace = true }
+momento-functions-host-log  = { workspace = true }
+momento-functions-token     = { workspace = true }
+
+log                         = { workspace = true }
+serde                       = { workspace = true }
+serde_json                  = { workspace = true }

--- a/examples/token-vending-machine/src/lib.rs
+++ b/examples/token-vending-machine/src/lib.rs
@@ -1,0 +1,72 @@
+//! Vends temporary, scoped Momento disposable tokens. Useful for handing out
+//! short-lived credentials without standing up a separate Lambda + API
+//! Gateway, while still being protected by the auth required to invoke the
+//! Function itself.
+//!
+//! This example issues a token that expires in 1 hour with:
+//! * Cache: read/write on all items in cache `foo`
+//! * Topic: subscribe-only on cache `foo`, topics prefixed with `notification-`
+//!
+//! `token_id` is a misnomer in the Momento protos — think of it as a secret
+//! payload baked into the issued JWT (which Momento signs). It can be a
+//! stringified JWT of your own service, a nonce, etc. Here we just use a
+//! placeholder string.
+
+use std::time::Duration;
+
+use momento_functions_bytes::{Data, encoding::Json};
+use momento_functions_guest_web::{WebEnvironment, WebResponse, WebResult, invoke};
+use momento_functions_host_log::{LogDestination, configure_logs};
+use momento_functions_token::{
+    CachePermissions, Permissions, TopicPermissions, generate_disposable_token,
+};
+use serde_json::json;
+
+#[derive(serde::Serialize)]
+struct Response {
+    api_key: String,
+    endpoint: String,
+    valid_until: u64,
+}
+
+invoke!(vend);
+fn vend(_payload: Data) -> WebResult<WebResponse> {
+    let env = WebEnvironment::load();
+    configure_logs([LogDestination::topic(env.function_name()).into()])?;
+
+    log::debug!("received request to generate a disposable token");
+    let permissions = Permissions::new()
+        .with_cache(
+            CachePermissions::read_write()
+                .with_cache("foo")
+                .with_all_items(),
+        )
+        .with_topic(
+            TopicPermissions::read_only()
+                .with_cache("foo")
+                .with_topic_prefix("notification-"),
+        );
+
+    let token_id = Some("my very secret value".to_string());
+
+    match generate_disposable_token(
+        Duration::from_secs(60 * 60).as_secs() as u32,
+        permissions,
+        token_id,
+    ) {
+        Ok(result) => Ok(WebResponse::new()
+            .with_status(200)
+            .header("Content-Type", "application/json")
+            .with_body(Json(Response {
+                api_key: result.api_key,
+                endpoint: result.endpoint,
+                valid_until: result.valid_until,
+            }))?),
+        Err(e) => {
+            log::error!("Failed to generate token: {e:?}");
+            Ok(WebResponse::new().with_status(500).with_body(json!({
+                "message": e.to_string(),
+            }))?)
+        }
+    }
+}

--- a/examples/turbopuffer-index-articles/Cargo.toml
+++ b/examples/turbopuffer-index-articles/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "example-turbopuffer-index-articles"
+version = "0.0.0"
+edition.workspace = true
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+momento-functions-bytes     = { workspace = true }
+momento-functions-guest-web = { workspace = true }
+momento-functions-host-log  = { workspace = true }
+momento-functions-http      = { workspace = true }
+
+itertools                   = { workspace = true }
+log                         = { workspace = true }
+serde                       = { workspace = true }
+serde_json                  = { workspace = true }
+tiktoken-rs                 = { workspace = true }

--- a/examples/turbopuffer-index-articles/src/lib.rs
+++ b/examples/turbopuffer-index-articles/src/lib.rs
@@ -1,0 +1,221 @@
+//! Indexes news articles into Turbopuffer. For each batch of documents we
+//! query OpenAI to generate embeddings, then upsert them into the configured
+//! Turbopuffer namespace.
+//!
+//! Required env vars: `OPENAI_API_KEY`, `TURBOPUFFER_REGION`,
+//! `TURBOPUFFER_NAMESPACE`, `TURBOPUFFER_API_KEY`.
+
+use itertools::Itertools;
+use momento_functions_bytes::encoding::{Extract, Json};
+use momento_functions_guest_web::{WebEnvironment, WebError, WebResponse, WebResult, invoke};
+use momento_functions_host_log::{LogDestination, configure_logs};
+use momento_functions_http::{Request as HttpRequest, invoke as http_invoke};
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use tiktoken_rs::{CoreBPE, cl100k_base_singleton};
+
+const OPENAI_URL: &str = "https://api.openai.com/v1/embeddings";
+const EMBEDDING_MODEL: &str = "text-embedding-3-small";
+const MAX_TOKENS: usize = 8192; // OpenAI's limit for text-embedding-3-small
+
+#[derive(Deserialize, Debug)]
+struct EmbeddingResponse {
+    data: Vec<EmbeddingData>,
+}
+#[derive(Deserialize, Serialize, Debug)]
+struct EmbeddingData {
+    embedding: Vec<f32>,
+    index: usize,
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+struct DocumentMetadata {
+    title: String,
+    link: String,
+    authors: Vec<String>,
+    language: String,
+    description: String,
+    feed: String,
+}
+
+#[derive(Deserialize, Debug)]
+struct DocumentInput {
+    id: String,
+    #[serde(alias = "metadata")]
+    document_metadata: DocumentMetadata,
+    page_content: String,
+}
+
+impl DocumentInput {
+    fn into_turbopuffer_document(self, vector: Vec<f32>) -> TurbopufferDocument {
+        TurbopufferDocument {
+            id: self.id,
+            page_content: self.page_content,
+            vector,
+            metadata_title: self.document_metadata.title,
+            metadata_link: self.document_metadata.link,
+            metadata_authors: self.document_metadata.authors,
+            metadata_language: self.document_metadata.language,
+            metadata_description: self.document_metadata.description,
+            metadata_feed: self.document_metadata.feed,
+        }
+    }
+}
+
+#[derive(Serialize, Debug)]
+struct TurbopufferDocument {
+    id: String,
+    page_content: String,
+    vector: Vec<f32>,
+    #[serde(rename = "metadata$title")]
+    metadata_title: String,
+    #[serde(rename = "metadata$link")]
+    metadata_link: String,
+    #[serde(rename = "metadata$authors")]
+    metadata_authors: Vec<String>,
+    #[serde(rename = "metadata$language")]
+    metadata_language: String,
+    #[serde(rename = "metadata$description")]
+    metadata_description: String,
+    #[serde(rename = "metadata$feed")]
+    metadata_feed: String,
+}
+
+invoke!(index_documents);
+fn index_documents(Json(documents): Json<Vec<DocumentInput>>) -> WebResult<WebResponse> {
+    setup_logging()?;
+
+    let bpe = cl100k_base_singleton();
+
+    if documents.is_empty() {
+        log::warn!("No documents provided for indexing.");
+        return Ok(WebResponse::new()
+            .with_status(400)
+            .with_body("No documents provided")?);
+    }
+
+    let turbopuffer_api_key = format!(
+        "Bearer {}",
+        std::env::var("TURBOPUFFER_API_KEY").unwrap_or_default()
+    );
+    let turbopuffer_region = std::env::var("TURBOPUFFER_REGION").unwrap_or_default();
+    let turbopuffer_namespace = std::env::var("TURBOPUFFER_NAMESPACE").unwrap_or_default();
+    let turbopuffer_endpoint = format!(
+        "https://{turbopuffer_region}.turbopuffer.com/v2/namespaces/{turbopuffer_namespace}"
+    );
+    let openai_api_key = std::env::var("OPENAI_API_KEY").unwrap_or_default();
+
+    // 100 is a reasonable batch size for OpenAI's embeddings endpoint.
+    for chunk in &documents.into_iter().chunks(100) {
+        let chunk: Vec<DocumentInput> = chunk.collect();
+        let page_contents = chunk.iter().map(|d| d.page_content.clone()).collect();
+        let embedding_data = get_embeddings(page_contents, &openai_api_key, bpe)?;
+
+        let mut to_upsert = Vec::with_capacity(chunk.len());
+        for (document, embedding) in chunk.into_iter().zip(embedding_data) {
+            to_upsert.push(document.into_turbopuffer_document(embedding.embedding));
+        }
+
+        index_in_turbopuffer(to_upsert, &turbopuffer_endpoint, &turbopuffer_api_key)?;
+    }
+
+    Ok(WebResponse::new()
+        .with_status(200)
+        .with_body(json!({ "message": "Documents indexed successfully" }).to_string())?)
+}
+
+fn index_in_turbopuffer(
+    rows: Vec<TurbopufferDocument>,
+    endpoint: &str,
+    api_key: &str,
+) -> WebResult<()> {
+    let response = http_invoke(
+        HttpRequest::new(endpoint, "POST")
+            .with_headers([
+                ("Authorization", api_key),
+                ("Content-Type", "application/json"),
+                ("Accept", "*/*"),
+                ("User-Agent", "momento-turbopuffer-example"),
+            ])
+            .with_body(
+                json!({
+                    "upsert_rows": rows,
+                    "distance_metric": "cosine_distance",
+                })
+                .to_string(),
+            ),
+    )?;
+    log::debug!("turbopuffer response status: {}", response.status);
+    if response.status != 200 {
+        let body = response.body.into_bytes();
+        let message = format!(
+            "Failed to index documents: {}",
+            String::from_utf8(body).unwrap_or_default()
+        );
+        return Err(WebError::message(message));
+    }
+    Ok(())
+}
+
+fn get_embeddings(
+    documents: Vec<String>,
+    openai_api_key: &str,
+    tokenizer: &'static CoreBPE,
+) -> WebResult<Vec<EmbeddingData>> {
+    log::debug!("getting embeddings for input");
+
+    let mut prepared = Vec::with_capacity(documents.len());
+    for document in &documents {
+        if document.is_empty() {
+            // OpenAI rejects empty inputs.
+            prepared.push("no_content".to_string());
+            continue;
+        }
+        let mut tokens = tokenizer.encode_with_special_tokens(document);
+        if tokens.len() > MAX_TOKENS {
+            log::debug!(
+                "token length was {}, truncating to {MAX_TOKENS}",
+                tokens.len(),
+            );
+            tokens.truncate(MAX_TOKENS);
+            prepared.push(tokenizer.decode(tokens).map_err(|e| {
+                WebError::message(format!(
+                    "Failed to convert truncated tokens back to string for OpenAI input: {e:?}"
+                ))
+            })?);
+        } else {
+            prepared.push(document.clone());
+        }
+    }
+
+    let response = http_invoke(
+        HttpRequest::new(OPENAI_URL, "POST")
+            .with_header("authorization", format!("Bearer {openai_api_key}"))
+            .with_header("content-type", "application/json")
+            .with_body(
+                json!({
+                    "model": EMBEDDING_MODEL,
+                    "encoding_format": "float",
+                    "input": prepared,
+                })
+                .to_string(),
+            ),
+    )?;
+    if response.status != 200 {
+        let bytes = response.body.into_bytes();
+        log::error!(
+            "OpenAI returned non-200: {}",
+            String::from_utf8_lossy(&bytes)
+        );
+        return Err(WebError::message("OpenAI failed to return embeddings"));
+    }
+    let Json(EmbeddingResponse { mut data }) = Json::<EmbeddingResponse>::extract(response.body)?;
+    data.sort_by_key(|d| d.index);
+    Ok(data)
+}
+
+fn setup_logging() -> WebResult<()> {
+    let env = WebEnvironment::load();
+    configure_logs([LogDestination::topic(env.function_name()).into()])?;
+    Ok(())
+}

--- a/examples/turbopuffer-index/Cargo.toml
+++ b/examples/turbopuffer-index/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "example-turbopuffer-index"
+version = "0.0.0"
+edition.workspace = true
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+momento-functions-bytes     = { workspace = true }
+momento-functions-guest-web = { workspace = true }
+momento-functions-host-log  = { workspace = true }
+momento-functions-http      = { workspace = true }
+
+itertools                   = { workspace = true }
+log                         = { workspace = true }
+serde                       = { workspace = true }
+serde_json                  = { workspace = true }

--- a/examples/turbopuffer-index/src/lib.rs
+++ b/examples/turbopuffer-index/src/lib.rs
@@ -1,0 +1,101 @@
+//! Indexes the documents from the `fine-foods-embeddings` example into a
+//! Turbopuffer namespace.
+//!
+//! Required env vars:
+//! * `TURBOPUFFER_REGION` — e.g. `gcp-us-central1`
+//! * `TURBOPUFFER_NAMESPACE`
+//! * `TURBOPUFFER_API_KEY`
+
+use itertools::Itertools;
+use momento_functions_bytes::encoding::Json;
+use momento_functions_guest_web::{WebEnvironment, WebResponse, WebResult, invoke};
+use momento_functions_host_log::{LogDestination, configure_logs};
+use momento_functions_http::{Request as HttpRequest, invoke as http_invoke};
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+
+/// Same as the `fine-foods-embeddings` output but with the embedding included.
+#[derive(Deserialize, Serialize, Debug)]
+struct Document {
+    #[serde(alias = "embedding")]
+    vector: Vec<f32>,
+    id: String,
+    product_id: String,
+    user_id: String,
+    profile_name: String,
+    helpfulness_numerator: i32,
+    helpfulness_denominator: i32,
+    score: i32,
+    time: u32,
+    summary: String,
+    text: String,
+}
+
+invoke!(index_document);
+fn index_document(Json(documents): Json<Vec<Document>>) -> WebResult<WebResponse> {
+    setup_logging()?;
+
+    let dimensions = match documents.first() {
+        Some(doc) => doc.vector.len(),
+        None => {
+            log::warn!("No documents provided for indexing.");
+            return Ok(WebResponse::new()
+                .with_status(400)
+                .with_body("No documents provided")?);
+        }
+    };
+    log::debug!(
+        "indexing {} documents with {dimensions} dimensions",
+        documents.len()
+    );
+
+    let turbopuffer_api_key = format!(
+        "Bearer {}",
+        std::env::var("TURBOPUFFER_API_KEY").unwrap_or_default()
+    );
+    let turbopuffer_region = std::env::var("TURBOPUFFER_REGION").unwrap_or_default();
+    let turbopuffer_namespace = std::env::var("TURBOPUFFER_NAMESPACE").unwrap_or_default();
+    let turbopuffer_endpoint = format!(
+        "https://{turbopuffer_region}.turbopuffer.com/v2/namespaces/{turbopuffer_namespace}"
+    );
+
+    for chunk in &documents.into_iter().chunks(2000) {
+        let chunk: Vec<Document> = chunk.collect();
+        let response = http_invoke(
+            HttpRequest::new(&turbopuffer_endpoint, "POST")
+                .with_headers([
+                    ("Authorization", turbopuffer_api_key.as_str()),
+                    ("Content-Type", "application/json"),
+                    ("Accept", "*/*"),
+                    ("User-Agent", "momento-turbopuffer-example"),
+                ])
+                .with_body(
+                    json!({
+                        "upsert_rows": chunk,
+                        "distance_metric": "cosine_distance",
+                    })
+                    .to_string(),
+                ),
+        )?;
+        if response.status != 200 {
+            let body = response.body.into_bytes();
+            let message = format!(
+                "Failed to index documents: {}",
+                String::from_utf8(body).unwrap_or_default()
+            );
+            return Ok(WebResponse::new()
+                .with_status(response.status)
+                .with_body(json!({ "message": message }).to_string())?);
+        }
+    }
+
+    Ok(WebResponse::new()
+        .with_status(200)
+        .with_body(json!({ "message": "Documents indexed successfully" }).to_string())?)
+}
+
+fn setup_logging() -> WebResult<()> {
+    let env = WebEnvironment::load();
+    configure_logs([LogDestination::topic(env.function_name()).into()])?;
+    Ok(())
+}

--- a/examples/turbopuffer-recommend-articles/Cargo.toml
+++ b/examples/turbopuffer-recommend-articles/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "example-turbopuffer-recommend-articles"
+version = "0.0.0"
+edition.workspace = true
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+momento-functions-bytes     = { workspace = true }
+momento-functions-cache     = { workspace = true }
+momento-functions-guest-web = { workspace = true }
+momento-functions-host-log  = { workspace = true }
+momento-functions-http      = { workspace = true }
+
+log                         = { workspace = true }
+serde                       = { workspace = true }
+serde_json                  = { workspace = true }

--- a/examples/turbopuffer-recommend-articles/src/lib.rs
+++ b/examples/turbopuffer-recommend-articles/src/lib.rs
@@ -1,0 +1,328 @@
+//! Recommends similar articles given a list of "preferred" article IDs.
+//! Looks up each article's embedding (cached in Momento Cache, refreshed
+//! from Turbopuffer on miss), averages the embeddings, then runs an ANN
+//! search excluding the seed articles. Filters out results whose cosine
+//! distance exceeds `MAXIMUM_COSINE_DISTANCE` to maintain quality.
+//!
+//! Required env vars: `TURBOPUFFER_REGION`, `TURBOPUFFER_NAMESPACE`,
+//! `TURBOPUFFER_API_KEY`. Optional: `TTL_SECONDS`.
+
+use std::{collections::HashMap, time::Duration};
+
+use momento_functions_bytes::encoding::{Extract, Json};
+use momento_functions_cache as cache;
+use momento_functions_guest_web::{WebEnvironment, WebError, WebResponse, WebResult, invoke};
+use momento_functions_host_log::{LogDestination, configure_logs};
+use momento_functions_http::{Request as HttpRequest, invoke as http_invoke};
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+
+#[derive(Deserialize, Debug)]
+struct Request {
+    article_ids: Vec<String>,
+    topk: Option<usize>,
+}
+
+#[derive(Deserialize, Debug)]
+struct QueryResponse {
+    rows: Vec<QueryRow>,
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+struct QueryRow {
+    #[serde(alias = "$dist", skip_serializing_if = "Option::is_none")]
+    dist: Option<f32>,
+    id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    vector: Option<Vec<f32>>,
+    #[serde(rename = "metadata$title", skip_serializing_if = "Option::is_none")]
+    metadata_title: Option<String>,
+    #[serde(rename = "metadata$link", skip_serializing_if = "Option::is_none")]
+    metadata_link: Option<String>,
+}
+
+const DEFAULT_TTL_SECONDS: u64 = 300;
+const MAXIMUM_COSINE_DISTANCE: f32 = 0.6;
+
+invoke!(get_recommended_articles);
+fn get_recommended_articles(Json(request): Json<Request>) -> WebResult<WebResponse> {
+    setup_logging()?;
+
+    let turbopuffer_api_key = format!(
+        "Bearer {}",
+        std::env::var("TURBOPUFFER_API_KEY").unwrap_or_default()
+    );
+    let turbopuffer_region = std::env::var("TURBOPUFFER_REGION").unwrap_or_default();
+    let turbopuffer_namespace = std::env::var("TURBOPUFFER_NAMESPACE").unwrap_or_default();
+    let turbopuffer_endpoint = format!(
+        "https://{turbopuffer_region}.turbopuffer.com/v2/namespaces/{turbopuffer_namespace}/query"
+    );
+    let ttl_seconds = std::env::var("TTL_SECONDS")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(DEFAULT_TTL_SECONDS);
+    let ttl = Duration::from_secs(ttl_seconds);
+
+    let Request { article_ids, topk } = request;
+    let topk = topk.unwrap_or(10);
+
+    let article_embeddings = get_article_embeddings(
+        article_ids.clone(),
+        &turbopuffer_endpoint,
+        &turbopuffer_api_key,
+        &ttl,
+    )?;
+
+    // Drop the IDs that didn't have an embedding before computing the mean.
+    let embeddings: Vec<Vec<f32>> = article_embeddings
+        .iter()
+        .filter_map(|(article_id, maybe_embedding)| {
+            if maybe_embedding.is_none() {
+                log::debug!("no embeddings found for {article_id}");
+            }
+            maybe_embedding.clone()
+        })
+        .collect();
+
+    let mean = mean_vector(&embeddings).unwrap_or_else(|| vec![0.0_f32; 1536]);
+
+    let recommended = get_similar_articles_from_turbopuffer(
+        mean,
+        article_ids,
+        topk,
+        &turbopuffer_endpoint,
+        &turbopuffer_api_key,
+    )?;
+
+    let response_body = serde_json::to_vec(&recommended)?;
+    Ok(WebResponse::new()
+        .with_status(200)
+        .header("Content-Type", "application/json")
+        .with_body(response_body)?)
+}
+
+fn get_article_embeddings(
+    article_ids: Vec<String>,
+    endpoint: &str,
+    api_key: &str,
+    ttl: &Duration,
+) -> WebResult<Vec<(String, Option<Vec<f32>>)>> {
+    log::debug!("Getting article embeddings from cache (if available)");
+    let mut embeddings_map: HashMap<String, Option<Vec<f32>>> = HashMap::new();
+    for article_id in &article_ids {
+        embeddings_map.insert(
+            article_id.clone(),
+            get_article_embeddings_from_cache(article_id.clone())?,
+        );
+    }
+
+    let cache_misses: Vec<String> = embeddings_map
+        .iter()
+        .filter_map(|(id, e)| e.is_none().then(|| id.clone()))
+        .collect();
+
+    if !cache_misses.is_empty() {
+        let fetched =
+            get_article_embeddings_from_turbopuffer(cache_misses, endpoint, api_key, ttl)?;
+        for (id, maybe_embedding) in fetched {
+            embeddings_map.insert(id, maybe_embedding);
+        }
+    }
+
+    // Reconstruct the original ordering.
+    let mut embeddings = Vec::with_capacity(article_ids.len());
+    for article_id in &article_ids {
+        embeddings.push((
+            article_id.clone(),
+            embeddings_map.get(article_id).cloned().unwrap_or_default(),
+        ));
+    }
+    Ok(embeddings)
+}
+
+fn get_article_embeddings_from_cache(article_id: String) -> WebResult<Option<Vec<f32>>> {
+    match cache::get::<Vec<u8>>(article_id.clone())? {
+        Some(hit) => {
+            log::debug!("cache hit for key '{article_id}'");
+            let embedding = hit
+                .chunks_exact(4)
+                .map(|chunk| {
+                    let arr = <[u8; 4]>::try_from(chunk)
+                        .map_err(|_| WebError::message("Chunk length should be 4"))?;
+                    Ok(f32::from_le_bytes(arr))
+                })
+                .collect::<WebResult<Vec<f32>>>()?;
+            Ok(Some(embedding))
+        }
+        None => {
+            log::debug!("cache miss for key '{article_id}'");
+            Ok(None)
+        }
+    }
+}
+
+fn get_article_embeddings_from_turbopuffer(
+    article_ids: Vec<String>,
+    endpoint: &str,
+    api_key: &str,
+    ttl: &Duration,
+) -> WebResult<Vec<(String, Option<Vec<f32>>)>> {
+    let response = http_invoke(
+        HttpRequest::new(endpoint, "POST")
+            .with_headers([
+                ("Authorization", api_key),
+                ("Content-Type", "application/json"),
+                ("Accept", "*/*"),
+                ("User-Agent", "momento-turbopuffer-example"),
+            ])
+            .with_body(
+                json!({
+                    "top_k": article_ids.len(),
+                    "include_attributes": vec!["id", "vector"],
+                    "filters": Filter::Comparison(ComparisonFilter(
+                        "id".to_string(),
+                        ComparisonOp::In,
+                        Value::Array(
+                            article_ids
+                                .iter()
+                                .map(|id| Value::String(id.clone()))
+                                .collect(),
+                        ),
+                    )),
+                })
+                .to_string(),
+            ),
+    )?;
+    if response.status != 200 {
+        let bytes = response.body.into_bytes();
+        return Err(WebError::message(format!(
+            "Failed to get indexed embeddings: {}",
+            String::from_utf8(bytes).unwrap_or_default()
+        )));
+    }
+    let Json(QueryResponse { rows }) = Json::<QueryResponse>::extract(response.body)?;
+
+    let mut embeddings = Vec::with_capacity(rows.len());
+    for row in rows {
+        if let Some(vector) = &row.vector {
+            let bytes: Vec<u8> = vector.iter().flat_map(|f| f.to_le_bytes()).collect();
+            log::debug!("setting in cache for {} with ttl {:?}", row.id, ttl);
+            cache::set(row.id.clone(), bytes, *ttl)?;
+        }
+        embeddings.push((row.id, row.vector.clone()));
+    }
+    Ok(embeddings)
+}
+
+fn get_similar_articles_from_turbopuffer(
+    mean_vector: Vec<f32>,
+    seen: Vec<String>,
+    topk: usize,
+    endpoint: &str,
+    api_key: &str,
+) -> WebResult<Vec<QueryRow>> {
+    let response = http_invoke(
+        HttpRequest::new(endpoint, "POST")
+            .with_headers([
+                ("Authorization", api_key),
+                ("Content-Type", "application/json"),
+                ("Accept", "*/*"),
+                ("User-Agent", "momento-turbopuffer-example"),
+            ])
+            .with_body(
+                json!({
+                    "rank_by": ["vector", "ANN", mean_vector],
+                    "top_k": topk,
+                    "include_attributes": vec!["metadata$title", "metadata$link"],
+                    "filters": Filter::Comparison(ComparisonFilter(
+                        "id".to_string(),
+                        ComparisonOp::NotIn,
+                        Value::Array(seen.iter().map(|id| Value::String(id.clone())).collect()),
+                    )),
+                })
+                .to_string(),
+            ),
+    )?;
+    if response.status != 200 {
+        let bytes = response.body.into_bytes();
+        return Err(WebError::message(format!(
+            "Failed to search documents: {}",
+            String::from_utf8(bytes).unwrap_or_default()
+        )));
+    }
+    let Json(QueryResponse { rows }) = Json::<QueryResponse>::extract(response.body)?;
+    Ok(rows
+        .into_iter()
+        .filter(|row| row.dist.unwrap_or_default() <= MAXIMUM_COSINE_DISTANCE)
+        .collect())
+}
+
+fn mean_vector(vectors: &[Vec<f32>]) -> Option<Vec<f32>> {
+    let total = vectors.len();
+    if total == 0 {
+        return None;
+    }
+    let dimensions = vectors[0].len();
+    let mut result = vec![0.0_f32; dimensions];
+
+    for v in vectors {
+        if v.len() != dimensions {
+            log::error!(
+                "Failed to calculate mean vector! Expected dimension {dimensions} but got {}",
+                v.len()
+            );
+            return None;
+        }
+        for (i, x) in v.iter().enumerate() {
+            result[i] += x;
+        }
+    }
+
+    let inv_avg = 1.0 / total as f32;
+    for x in &mut result {
+        *x *= inv_avg;
+    }
+    Some(result)
+}
+
+fn setup_logging() -> WebResult<()> {
+    let env = WebEnvironment::load();
+    configure_logs([LogDestination::topic(env.function_name()).into()])?;
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Recursive filter representation, see turbopuffer-search-articles.
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum Filter {
+    Logical(LogicalFilter),
+    Not(NotFilter),
+    Comparison(ComparisonFilter),
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct LogicalFilter(pub String, pub Vec<Filter>);
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct NotFilter(pub String, pub Box<Filter>);
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ComparisonFilter(pub String, pub ComparisonOp, pub Value);
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub enum ComparisonOp {
+    Eq,
+    Neq,
+    In,
+    NotIn,
+    Lt,
+    Lte,
+    Gt,
+    Gte,
+    Glob,
+    NotGlob,
+}

--- a/examples/turbopuffer-recommend-articles/src/lib.rs
+++ b/examples/turbopuffer-recommend-articles/src/lib.rs
@@ -118,7 +118,8 @@ fn get_article_embeddings(
 
     let cache_misses: Vec<String> = embeddings_map
         .iter()
-        .filter_map(|(id, e)| e.is_none().then(|| id.clone()))
+        .filter(|(_, e)| e.is_none())
+        .map(|(id, _)| id.clone())
         .collect();
 
     if !cache_misses.is_empty() {

--- a/examples/turbopuffer-search-articles/Cargo.toml
+++ b/examples/turbopuffer-search-articles/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "example-turbopuffer-search-articles"
+version = "0.0.0"
+edition.workspace = true
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+momento-functions-bytes     = { workspace = true }
+momento-functions-cache     = { workspace = true }
+momento-functions-guest-web = { workspace = true }
+momento-functions-host-log  = { workspace = true }
+momento-functions-http      = { workspace = true }
+
+log                         = { workspace = true }
+serde                       = { workspace = true }
+serde_json                  = { workspace = true }

--- a/examples/turbopuffer-search-articles/src/lib.rs
+++ b/examples/turbopuffer-search-articles/src/lib.rs
@@ -1,0 +1,232 @@
+//! After indexing articles with `turbopuffer-index-articles`, query them by
+//! text. The query embedding is fetched from OpenAI on miss and cached in
+//! Momento Cache to keep response latency low.
+//!
+//! Required env vars: `OPENAI_API_KEY`, `TURBOPUFFER_REGION`,
+//! `TURBOPUFFER_NAMESPACE`, `TURBOPUFFER_API_KEY`. Optional: `TTL_SECONDS`.
+
+use std::time::Duration;
+
+use momento_functions_bytes::encoding::{Extract, Json};
+use momento_functions_cache as cache;
+use momento_functions_guest_web::{WebEnvironment, WebError, WebResponse, WebResult, invoke};
+use momento_functions_host_log::{LogDestination, configure_logs};
+use momento_functions_http::{Request as HttpRequest, invoke as http_invoke};
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+
+#[derive(Deserialize, Debug)]
+struct Request {
+    query: String,
+    topk: Option<usize>,
+    include_attributes: Option<Vec<String>>,
+    filters: Option<Filter>,
+}
+
+#[derive(Deserialize, Debug)]
+struct EmbeddingResponse {
+    data: Vec<EmbeddingData>,
+}
+#[derive(Deserialize, Serialize, Debug)]
+struct EmbeddingData {
+    embedding: Vec<f32>,
+    index: usize,
+}
+
+#[derive(Deserialize, Debug)]
+struct QueryResponse {
+    rows: Vec<QueryRow>,
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+struct QueryRow {
+    #[serde(alias = "$dist")]
+    dist: f32,
+    id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    vector: Option<Vec<f32>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    page_content: Option<String>,
+    #[serde(rename = "metadata$title", skip_serializing_if = "Option::is_none")]
+    metadata_title: Option<String>,
+    #[serde(rename = "metadata$link", skip_serializing_if = "Option::is_none")]
+    metadata_link: Option<String>,
+    #[serde(rename = "metadata$authors", skip_serializing_if = "Option::is_none")]
+    metadata_authors: Option<Vec<String>>,
+    #[serde(rename = "metadata$language", skip_serializing_if = "Option::is_none")]
+    metadata_language: Option<String>,
+    #[serde(
+        rename = "metadata$description",
+        skip_serializing_if = "Option::is_none"
+    )]
+    metadata_description: Option<String>,
+    #[serde(rename = "metadata$feed", skip_serializing_if = "Option::is_none")]
+    metadata_feed: Option<String>,
+}
+
+const DEFAULT_TTL_SECONDS: u64 = 30;
+
+invoke!(search);
+fn search(Json(request): Json<Request>) -> WebResult<WebResponse> {
+    setup_logging()?;
+
+    let Request {
+        query,
+        topk,
+        include_attributes,
+        filters,
+    } = request;
+    let embeddings = get_cached_query_embedding(query)?;
+    let topk = topk.unwrap_or(5);
+    let include_attributes = include_attributes.unwrap_or_default();
+
+    let turbopuffer_api_key = format!(
+        "Bearer {}",
+        std::env::var("TURBOPUFFER_API_KEY").unwrap_or_default()
+    );
+    let turbopuffer_region = std::env::var("TURBOPUFFER_REGION").unwrap_or_default();
+    let turbopuffer_namespace = std::env::var("TURBOPUFFER_NAMESPACE").unwrap_or_default();
+    let turbopuffer_endpoint = format!(
+        "https://{turbopuffer_region}.turbopuffer.com/v2/namespaces/{turbopuffer_namespace}/query"
+    );
+
+    log::debug!("querying turbopuffer with topk={topk}, include_attributes={include_attributes:?}");
+    let response = http_invoke(
+        HttpRequest::new(turbopuffer_endpoint, "POST")
+            .with_headers([
+                ("Authorization", turbopuffer_api_key.as_str()),
+                ("Content-Type", "application/json"),
+                ("Accept", "*/*"),
+                ("User-Agent", "momento-turbopuffer-example"),
+            ])
+            .with_body(
+                json!({
+                    "rank_by": ["vector", "ANN", embeddings],
+                    "top_k": topk,
+                    "include_attributes": include_attributes,
+                    "filters": filters,
+                })
+                .to_string(),
+            ),
+    )?;
+
+    if response.status != 200 {
+        let body = response.body.into_bytes();
+        let message = format!(
+            "Failed to search documents: {}",
+            String::from_utf8(body).unwrap_or_default()
+        );
+        return Ok(WebResponse::new()
+            .with_status(response.status)
+            .with_body(json!({ "message": message }).to_string())?);
+    }
+
+    let Json(QueryResponse { rows }) = Json::<QueryResponse>::extract(response.body)?;
+    let response_body = serde_json::to_vec(&rows)?;
+    Ok(WebResponse::new()
+        .with_status(200)
+        .header("Content-Type", "application/json")
+        .with_body(response_body)?)
+}
+
+fn get_cached_query_embedding(query: String) -> WebResult<Vec<f32>> {
+    log::debug!("Checking if embeddings are already cached for \"{query}\"");
+    if let Some(hit) = cache::get::<Vec<u8>>(query.clone())? {
+        log::debug!("cache hit");
+        return hit
+            .chunks_exact(4)
+            .map(|chunk| {
+                let arr = <[u8; 4]>::try_from(chunk)
+                    .map_err(|_| WebError::message("Chunk length should be 4"))?;
+                Ok(f32::from_le_bytes(arr))
+            })
+            .collect();
+    }
+
+    log::debug!("cache miss, querying embeddings from OpenAI");
+    let embedding = get_embeddings(query.clone())?
+        .into_iter()
+        .next()
+        .ok_or_else(|| {
+            log::error!("Failed to get embedding for query: {query}");
+            WebError::message("Failed to get embedding for query")
+        })?;
+
+    let bytes: Vec<u8> = embedding
+        .embedding
+        .iter()
+        .flat_map(|f| f.to_le_bytes())
+        .collect();
+    let ttl: u64 = std::env::var("TTL_SECONDS")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(DEFAULT_TTL_SECONDS);
+    cache::set(query, bytes, Duration::from_secs(ttl))?;
+    Ok(embedding.embedding)
+}
+
+fn get_embeddings(query: String) -> WebResult<Vec<EmbeddingData>> {
+    log::debug!("getting embeddings for content: {query:?}");
+    let query = query.replace('\n', " ");
+
+    let openai_api_key = std::env::var("OPENAI_API_KEY").unwrap_or_default();
+    let response = http_invoke(
+        HttpRequest::new("https://api.openai.com/v1/embeddings", "POST")
+            .with_header("authorization", format!("Bearer {openai_api_key}"))
+            .with_header("content-type", "application/json")
+            .with_body(
+                serde_json::json!({
+                    "model": "text-embedding-3-small",
+                    "encoding_format": "float",
+                    "input": [query],
+                })
+                .to_string(),
+            ),
+    )?;
+    let Json(EmbeddingResponse { mut data }) = Json::<EmbeddingResponse>::extract(response.body)?;
+    data.sort_by_key(|d| d.index);
+    Ok(data)
+}
+
+fn setup_logging() -> WebResult<()> {
+    let env = WebEnvironment::load();
+    configure_logs([LogDestination::topic(env.function_name()).into()])?;
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Recursive filter representation. Turbopuffer validates the structure;
+// these types just carry it across the wire.
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum Filter {
+    Logical(LogicalFilter),
+    Not(NotFilter),
+    Comparison(ComparisonFilter),
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct LogicalFilter(pub String, pub Vec<Filter>);
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct NotFilter(pub String, pub Box<Filter>);
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ComparisonFilter(pub String, pub ComparisonOp, pub Value);
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub enum ComparisonOp {
+    Eq,
+    Neq,
+    In,
+    NotIn,
+    Lt,
+    Lte,
+    Gt,
+    Gte,
+    Glob,
+    NotGlob,
+}

--- a/examples/turbopuffer-search/Cargo.toml
+++ b/examples/turbopuffer-search/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "example-turbopuffer-search"
+version = "0.0.0"
+edition.workspace = true
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+momento-functions-bytes     = { workspace = true }
+momento-functions-cache     = { workspace = true }
+momento-functions-guest-web = { workspace = true }
+momento-functions-host-log  = { workspace = true }
+momento-functions-http      = { workspace = true }
+
+log                         = { workspace = true }
+serde                       = { workspace = true }
+serde_json                  = { workspace = true }

--- a/examples/turbopuffer-search/src/lib.rs
+++ b/examples/turbopuffer-search/src/lib.rs
@@ -1,0 +1,179 @@
+//! Nearest-neighbor search through documents indexed in Turbopuffer.
+//! Caches the OpenAI embedding for the query in Momento Cache to avoid
+//! repeat API calls.
+//!
+//! Required env vars: `OPENAI_API_KEY`, `TURBOPUFFER_REGION`,
+//! `TURBOPUFFER_NAMESPACE`, `TURBOPUFFER_API_KEY`. Optional: `TTL` (seconds,
+//! defaults to 30).
+//!
+//! ```bash
+//! curl https://api.cache.$MOMENTO_CELL_HOSTNAME/functions/$MOMENTO_CACHE_NAME/turbopuffer-search \
+//!   -H "authorization: $MOMENTO_API_KEY" \
+//!   -H "Content-Type: application/json" \
+//!   -d '{"topk": 5, "query": "sweet food"}'
+//! ```
+
+use std::time::Duration;
+
+use momento_functions_bytes::encoding::{Extract, Json};
+use momento_functions_cache as cache;
+use momento_functions_guest_web::{WebEnvironment, WebError, WebResponse, WebResult, invoke};
+use momento_functions_host_log::{LogDestination, configure_logs};
+use momento_functions_http::{Request as HttpRequest, invoke as http_invoke};
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+
+#[derive(Deserialize, Debug)]
+struct Request {
+    query: String,
+    topk: Option<usize>,
+    include_attributes: Option<Vec<String>>,
+}
+
+#[derive(Deserialize, Debug)]
+struct EmbeddingResponse {
+    data: Vec<EmbeddingData>,
+}
+#[derive(Deserialize, Serialize, Debug)]
+struct EmbeddingData {
+    embedding: Vec<f32>,
+    index: usize,
+}
+
+#[derive(Deserialize, Debug)]
+struct QueryResponse {
+    rows: Vec<QueryRow>,
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+struct QueryRow {
+    #[serde(alias = "$dist")]
+    dist: f32,
+    id: String,
+}
+
+const DEFAULT_TTL_SECONDS: u64 = 30;
+
+invoke!(search);
+fn search(Json(request): Json<Request>) -> WebResult<WebResponse> {
+    setup_logging()?;
+
+    let Request {
+        query,
+        topk,
+        include_attributes,
+    } = request;
+    let embeddings = get_cached_query_embedding(query)?;
+    let topk = topk.unwrap_or(5);
+    let include_attributes = include_attributes.unwrap_or_default();
+
+    let turbopuffer_api_key = format!(
+        "Bearer {}",
+        std::env::var("TURBOPUFFER_API_KEY").unwrap_or_default()
+    );
+    let turbopuffer_region = std::env::var("TURBOPUFFER_REGION").unwrap_or_default();
+    let turbopuffer_namespace = std::env::var("TURBOPUFFER_NAMESPACE").unwrap_or_default();
+    let turbopuffer_endpoint = format!(
+        "https://{turbopuffer_region}.turbopuffer.com/v2/namespaces/{turbopuffer_namespace}/query"
+    );
+
+    let response = http_invoke(
+        HttpRequest::new(turbopuffer_endpoint, "POST")
+            .with_headers([
+                ("Authorization", turbopuffer_api_key.as_str()),
+                ("Content-Type", "application/json"),
+                ("Accept", "*/*"),
+                ("User-Agent", "momento-turbopuffer-example"),
+            ])
+            .with_body(
+                json!({
+                    "rank_by": ["vector", "ANN", embeddings],
+                    "top_k": topk,
+                    "include_attributes": include_attributes,
+                })
+                .to_string(),
+            ),
+    )?;
+
+    if response.status != 200 {
+        let body = response.body.into_bytes();
+        let message = format!(
+            "Failed to search documents: {}",
+            String::from_utf8(body).unwrap_or_default()
+        );
+        return Ok(WebResponse::new()
+            .with_status(response.status)
+            .with_body(json!({ "message": message }).to_string())?);
+    }
+    let Json(QueryResponse { rows }) = Json::<QueryResponse>::extract(response.body)?;
+    let response_body = serde_json::to_vec(&rows)?;
+    Ok(WebResponse::new()
+        .with_status(200)
+        .header("Content-Type", "application/json")
+        .with_body(response_body)?)
+}
+
+fn get_cached_query_embedding(query: String) -> WebResult<Vec<f32>> {
+    log::debug!("Checking if embeddings are already cached for \"{query}\"");
+    if let Some(hit) = cache::get::<Vec<u8>>(query.clone())? {
+        log::debug!("cache hit");
+        return hit
+            .chunks_exact(4)
+            .map(|chunk| {
+                let arr = <[u8; 4]>::try_from(chunk)
+                    .map_err(|_| WebError::message("Chunk length should be 4"))?;
+                Ok(f32::from_le_bytes(arr))
+            })
+            .collect();
+    }
+
+    log::debug!("cache miss, querying embeddings from OpenAI");
+    let embedding = get_embeddings(query.clone())?
+        .into_iter()
+        .next()
+        .ok_or_else(|| {
+            log::error!("Failed to get embedding for query: {query}");
+            WebError::message("Failed to get embedding for query")
+        })?;
+
+    let bytes: Vec<u8> = embedding
+        .embedding
+        .iter()
+        .flat_map(|f| f.to_le_bytes())
+        .collect();
+    let ttl: u64 = std::env::var("TTL")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(DEFAULT_TTL_SECONDS);
+    cache::set(query, bytes, Duration::from_secs(ttl))?;
+    Ok(embedding.embedding)
+}
+
+fn get_embeddings(mut query: String) -> WebResult<Vec<EmbeddingData>> {
+    log::debug!("getting embeddings for document with content: {query:?}");
+    query.truncate(10_000);
+
+    let openai_api_key = std::env::var("OPENAI_API_KEY").unwrap_or_default();
+    let response = http_invoke(
+        HttpRequest::new("https://api.openai.com/v1/embeddings", "POST")
+            .with_header("authorization", format!("Bearer {openai_api_key}"))
+            .with_header("content-type", "application/json")
+            .with_body(
+                serde_json::json!({
+                    "model": "text-embedding-3-small",
+                    "encoding_format": "float",
+                    "input": [query],
+                })
+                .to_string(),
+            ),
+    )?;
+    let Json(EmbeddingResponse { mut data }) = Json::<EmbeddingResponse>::extract(response.body)?;
+    data.sort_by_key(|d| d.index);
+    Ok(data)
+}
+
+fn setup_logging() -> WebResult<()> {
+    let env = WebEnvironment::load();
+    configure_logs([LogDestination::topic(env.function_name()).into()])?;
+    Ok(())
+}

--- a/examples/valkey-cluster-vector-index/Cargo.toml
+++ b/examples/valkey-cluster-vector-index/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "example-valkey-cluster-vector-index"
+version = "0.0.0"
+edition.workspace = true
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+momento-functions-bytes     = { workspace = true }
+momento-functions-guest-web = { workspace = true }
+momento-functions-host-log  = { workspace = true }
+momento-functions-valkey    = { workspace = true }
+
+log                         = { workspace = true }
+serde                       = { workspace = true }
+serde_json                  = { workspace = true }

--- a/examples/valkey-cluster-vector-index/src/lib.rs
+++ b/examples/valkey-cluster-vector-index/src/lib.rs
@@ -1,0 +1,120 @@
+//! Indexes a batch of documents into a Momento-managed Valkey cluster as
+//! HSET hashes with a `vector` field. The index is created on demand. Pass
+//! the cluster name via `CLUSTER_NAME` when deploying.
+
+use std::collections::HashMap;
+
+use momento_functions_bytes::encoding::Json;
+use momento_functions_guest_web::{WebEnvironment, WebResponse, WebResult, invoke};
+use momento_functions_host_log::{LogConfiguration, LogDestination, configure_logs};
+use momento_functions_valkey::{Command, Value, get_managed_cluster_client};
+use serde::Deserialize;
+use serde_json::json;
+
+#[derive(Deserialize, Debug)]
+struct Request {
+    documents: Vec<Document>,
+}
+#[derive(Deserialize, Debug)]
+struct Document {
+    id: String,
+    embedding: Vec<f32>,
+    fields: HashMap<String, String>,
+}
+
+invoke!(index_document);
+fn index_document(Json(body): Json<Request>) -> WebResult<WebResponse> {
+    setup_logging()?;
+
+    let Request { documents } = body;
+    log::debug!("indexing {} documents", documents.len());
+
+    let dimensions = match documents.first() {
+        Some(doc) => doc.embedding.len(),
+        None => {
+            log::warn!("No documents provided for indexing.");
+            return Ok(WebResponse::new()
+                .with_status(400)
+                .with_body("No documents provided")?);
+        }
+    };
+
+    let cluster_name = std::env::var("CLUSTER_NAME").unwrap_or_default();
+    log::debug!("Connecting to managed Valkey cluster {cluster_name}");
+    let client = get_managed_cluster_client(&cluster_name);
+    log::info!("created client");
+
+    ensure_index_exists(dimensions, &client)?;
+
+    let length = documents.len();
+    for document in documents {
+        let mut cmd = Command::builder("HSET");
+        cmd.argument(document.id);
+        for (key, value) in document.fields {
+            cmd.argument(key).argument(value);
+        }
+        let embedding: Vec<u8> = document
+            .embedding
+            .into_iter()
+            .flat_map(f32::to_le_bytes)
+            .collect();
+        cmd.argument("vector").argument(embedding);
+        client.command(cmd)?;
+    }
+
+    Ok(WebResponse::new().with_status(200).with_body(Json(json!({
+        "message": "Documents indexed successfully",
+        "indexed_count": length,
+    })))?)
+}
+
+fn ensure_index_exists(
+    dimensions: usize,
+    client: &momento_functions_valkey::ClusterClient,
+) -> WebResult<()> {
+    let mut info = Command::builder("FT.INFO");
+    info.argument("document_index");
+
+    match client.command(info) {
+        Ok(Value::Bulk(_)) | Ok(Value::Ok) | Ok(Value::SimpleString(_)) => {
+            log::debug!("index already exists");
+        }
+        Ok(_) | Err(_) => {
+            log::info!("index does not exist or returned unexpected shape, creating it");
+            create_index(dimensions, client)?;
+        }
+    }
+    Ok(())
+}
+
+fn create_index(
+    dimensions: usize,
+    client: &momento_functions_valkey::ClusterClient,
+) -> WebResult<()> {
+    let mut create = Command::builder("FT.CREATE");
+    create
+        .argument("document_index")
+        .argument("SCHEMA")
+        .argument("vector")
+        .argument("VECTOR")
+        .argument("HNSW")
+        .argument("6")
+        .argument("TYPE")
+        .argument("FLOAT32")
+        .argument("DIM")
+        .argument(dimensions.to_string())
+        .argument("DISTANCE_METRIC")
+        .argument("COSINE");
+    client.command(create)?;
+    log::info!("Index created successfully");
+    Ok(())
+}
+
+fn setup_logging() -> WebResult<()> {
+    let env = WebEnvironment::load();
+    configure_logs([
+        LogConfiguration::new(LogDestination::topic(env.function_name()))
+            .with_log_level(log::LevelFilter::Debug),
+    ])?;
+    Ok(())
+}

--- a/examples/valkey-cluster-vector-search/Cargo.toml
+++ b/examples/valkey-cluster-vector-search/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "example-valkey-cluster-vector-search"
+version = "0.0.0"
+edition.workspace = true
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+momento-functions-bytes     = { workspace = true }
+momento-functions-guest-web = { workspace = true }
+momento-functions-host-log  = { workspace = true }
+momento-functions-http      = { workspace = true }
+momento-functions-valkey    = { workspace = true }
+
+log                         = { workspace = true }
+serde                       = { workspace = true }
+serde_json                  = { workspace = true }
+sha2                        = { workspace = true }

--- a/examples/valkey-cluster-vector-search/src/lib.rs
+++ b/examples/valkey-cluster-vector-search/src/lib.rs
@@ -1,0 +1,299 @@
+//! Performs a KNN vector search against a managed Valkey cluster by
+//! converting a text query to an embedding via OpenAI (caching the
+//! embedding bytes in Valkey under the query's SHA-256 hash). Pass the
+//! cluster name via `CLUSTER_NAME` when deploying.
+
+use std::{collections::HashMap, mem::take};
+
+use momento_functions_bytes::encoding::{Extract, Json};
+use momento_functions_guest_web::{WebEnvironment, WebError, WebResponse, WebResult, invoke};
+use momento_functions_host_log::{LogDestination, configure_logs};
+use momento_functions_http::{Request as HttpRequest, invoke as http_invoke};
+use momento_functions_valkey::{ClusterClient, Command, Value, get_managed_cluster_client};
+use serde::{Deserialize, Serialize};
+use sha2::Digest;
+
+#[derive(Deserialize, Debug)]
+struct Request {
+    query: String,
+    topk: Option<usize>,
+}
+
+#[derive(Serialize, Debug)]
+struct Document {
+    id: String,
+    __vector_score: f32,
+    #[serde(flatten)]
+    fields: HashMap<String, String>,
+}
+
+invoke!(search);
+fn search(Json(body): Json<Request>) -> WebResult<WebResponse> {
+    setup_logging()?;
+
+    let Request { query, topk } = body;
+    let topk = topk.unwrap_or(5);
+    log::debug!("getting top {topk} documents for search: {query:?}");
+
+    let mut hasher = sha2::Sha256::new();
+    hasher.update(query.as_bytes());
+    let query_hash: [u8; 32] = hasher.finalize().into();
+
+    let cluster_name = std::env::var("CLUSTER_NAME").unwrap_or_default();
+    let client = get_managed_cluster_client(&cluster_name);
+    let query_embedding = get_cached_query_embedding(query, query_hash, &client)?;
+
+    let mut cmd = Command::builder("FT.SEARCH");
+    cmd.argument("document_index")
+        .argument(format!("*=>[KNN {topk} @vector $query_vector]"))
+        .argument("PARAMS")
+        .argument("2")
+        .argument("query_vector")
+        .argument(query_embedding);
+    let response = client.command(cmd)?;
+
+    let mut responses = match response {
+        Value::Bulk(items) => items,
+        Value::SimpleError(e) => {
+            log::error!("Valkey error: {e}");
+            return Err(WebError::message(format!("Valkey error: {e}")));
+        }
+        _ => return Err(WebError::message("Unexpected Valkey response")),
+    };
+
+    let topk_actual = responses
+        .next()
+        .ok_or_else(|| WebError::message("No results returned from Valkey"))?;
+    let topk_actual = match topk_actual {
+        Value::Int(count) => count as usize,
+        _ => {
+            return Err(WebError::message(
+                "Expected an integer for the number of results",
+            ));
+        }
+    };
+
+    let mut documents: Vec<Document> = Vec::with_capacity(topk_actual);
+    loop {
+        log::debug!("reading next document");
+        let value = match responses.next() {
+            Some(value) => value,
+            None => break,
+        };
+
+        let mut parser;
+        match value {
+            Value::Data(_) => {
+                parser = ParserExpect::DocumentId;
+                parser.try_parse(value)?;
+            }
+            Value::SimpleError(e) => {
+                log::error!("Valkey error: {e}");
+                return Err(WebError::message(format!("Valkey error: {e}")));
+            }
+            _ => return Err(WebError::message("Unexpected Valkey response")),
+        }
+
+        let value = responses
+            .next()
+            .ok_or_else(|| WebError::message("Unexpected end of response after document ID"))?;
+        match value {
+            Value::Bulk(items) => {
+                let mut skip = 0;
+                for item in items {
+                    if skip != 0 {
+                        skip -= 1;
+                        continue;
+                    }
+                    skip = parser.try_parse(item)?;
+                }
+            }
+            Value::SimpleError(e) => {
+                log::error!("Valkey error: {e}");
+                return Err(WebError::message(format!("Valkey error: {e}")));
+            }
+            _ => return Err(WebError::message("Unexpected Valkey response")),
+        }
+        match parser {
+            ParserExpect::FieldName {
+                id,
+                vector_score,
+                fields,
+            } => documents.push(Document {
+                id,
+                __vector_score: vector_score,
+                fields,
+            }),
+            _ => return Err(WebError::message("Unexpected parser terminal state")),
+        }
+    }
+
+    Ok(WebResponse::new()
+        .with_status(200)
+        .with_headers(vec![(
+            "content-type".to_string(),
+            "application/json".to_string(),
+        )])
+        .with_body(Json(documents))?)
+}
+
+#[derive(Debug)]
+enum ParserExpect {
+    DocumentId,
+    VectorScore {
+        id: String,
+    },
+    FieldName {
+        id: String,
+        vector_score: f32,
+        fields: HashMap<String, String>,
+    },
+    FieldValue {
+        id: String,
+        vector_score: f32,
+        fields: HashMap<String, String>,
+        name: String,
+    },
+}
+
+impl ParserExpect {
+    fn try_parse(&mut self, value: Value) -> WebResult<usize> {
+        match self {
+            ParserExpect::DocumentId => {
+                let bytes = expect_data(value, "document ID")?;
+                *self = ParserExpect::VectorScore {
+                    id: String::from_utf8(bytes).map_err(|e| {
+                        WebError::message(format!("Failed to parse document ID: {e}"))
+                    })?,
+                };
+                Ok(0)
+            }
+            ParserExpect::VectorScore { id } => {
+                let bytes = expect_data(value, "vector score")?;
+                let raw = String::from_utf8(bytes).map_err(|e| {
+                    WebError::message(format!("failed to parse vector score as utf8: {e:?}"))
+                })?;
+                if raw == "__vector_score" {
+                    return Ok(0);
+                }
+                let vector_score = raw.parse().map_err(|e| {
+                    WebError::message(format!("Failed to parse vector score: {e:?}"))
+                })?;
+                *self = ParserExpect::FieldName {
+                    id: take(id),
+                    vector_score,
+                    fields: HashMap::new(),
+                };
+                Ok(0)
+            }
+            ParserExpect::FieldName {
+                id,
+                vector_score,
+                fields,
+            } => {
+                let bytes = expect_data(value, "field name")?;
+                let name = String::from_utf8(bytes)
+                    .map_err(|e| WebError::message(format!("Failed to parse field name: {e}")))?;
+                if name == "vector" {
+                    return Ok(1);
+                }
+                *self = ParserExpect::FieldValue {
+                    id: take(id),
+                    vector_score: *vector_score,
+                    fields: take(fields),
+                    name,
+                };
+                Ok(0)
+            }
+            ParserExpect::FieldValue {
+                id,
+                vector_score,
+                fields,
+                name,
+            } => {
+                let bytes = expect_data(value, "field value")?;
+                let field_value = String::from_utf8(bytes)
+                    .map_err(|e| WebError::message(format!("Failed to parse field value: {e}")))?;
+                fields.insert(name.clone(), field_value);
+                *self = ParserExpect::FieldName {
+                    id: take(id),
+                    vector_score: *vector_score,
+                    fields: take(fields),
+                };
+                Ok(0)
+            }
+        }
+    }
+}
+
+fn expect_data(value: Value, what: &str) -> WebResult<Vec<u8>> {
+    match value {
+        Value::Data(data) => Ok(data.into_bytes()),
+        _ => Err(WebError::message(format!("Expected Data type for {what}"))),
+    }
+}
+
+fn get_cached_query_embedding(
+    query: String,
+    query_hash: [u8; 32],
+    client: &ClusterClient,
+) -> WebResult<Vec<u8>> {
+    match client.command(Command::get(query_hash.to_vec()))? {
+        Value::Data(data) => {
+            log::debug!("cache hit for query embedding");
+            Ok(data.into_bytes())
+        }
+        Value::Nil => {
+            log::debug!("cache miss, querying embeddings from OpenAI");
+            let embedding = get_embedding(&query)?;
+            let bytes: Vec<u8> = embedding.iter().flat_map(|f| f.to_le_bytes()).collect();
+            client.command(Command::set(query_hash.to_vec(), bytes.clone()))?;
+            Ok(bytes)
+        }
+        _ => {
+            log::warn!("unexpected valkey GET response, treating as miss");
+            let embedding = get_embedding(&query)?;
+            Ok(embedding.iter().flat_map(|f| f.to_le_bytes()).collect())
+        }
+    }
+}
+
+#[derive(Deserialize, Debug)]
+struct EmbeddingResponse {
+    data: Vec<EmbeddingData>,
+}
+#[derive(Deserialize, Serialize, Debug)]
+struct EmbeddingData {
+    embedding: Vec<f32>,
+    index: usize,
+}
+
+fn get_embedding(query: &str) -> WebResult<Vec<f32>> {
+    let query = query.replace('\n', " ");
+    let openai_api_key = std::env::var("OPENAI_API_KEY").unwrap_or_default();
+    let response = http_invoke(
+        HttpRequest::new("https://api.openai.com/v1/embeddings", "POST")
+            .with_header("authorization", format!("Bearer {openai_api_key}"))
+            .with_header("content-type", "application/json")
+            .with_body(
+                serde_json::json!({
+                    "model": "text-embedding-3-small",
+                    "encoding_format": "float",
+                    "input": [query],
+                })
+                .to_string(),
+            ),
+    )?;
+    let Json(EmbeddingResponse { mut data }) = Json::<EmbeddingResponse>::extract(response.body)?;
+    data.sort_by_key(|d| d.index);
+    data.into_iter()
+        .next()
+        .map(|d| d.embedding)
+        .ok_or_else(|| WebError::message("Failed to get embedding for query"))
+}
+
+fn setup_logging() -> WebResult<()> {
+    let env = WebEnvironment::load();
+    configure_logs([LogDestination::topic(env.function_name()).into()])?;
+    Ok(())
+}

--- a/examples/valkey-vector-embeddings/Cargo.toml
+++ b/examples/valkey-vector-embeddings/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "example-valkey-vector-embeddings"
+version = "0.0.0"
+edition.workspace = true
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+momento-functions-bytes     = { workspace = true }
+momento-functions-guest-web = { workspace = true }
+momento-functions-host-log  = { workspace = true }
+momento-functions-http      = { workspace = true }
+
+log                         = { workspace = true }
+serde                       = { workspace = true }
+serde_json                  = { workspace = true }

--- a/examples/valkey-vector-embeddings/src/lib.rs
+++ b/examples/valkey-vector-embeddings/src/lib.rs
@@ -1,0 +1,68 @@
+//! Request embeddings from OpenAI for a batch of documents. Serves as the
+//! embedding producer used by the other valkey-vector-* examples.
+
+use momento_functions_bytes::encoding::{Extract, Json};
+use momento_functions_guest_web::{WebEnvironment, WebResponse, WebResult, invoke};
+use momento_functions_host_log::{LogDestination, configure_logs};
+use momento_functions_http::{Request as HttpRequest, invoke as http_invoke};
+use serde::{Deserialize, Serialize};
+
+#[derive(Deserialize, Debug)]
+struct Request {
+    documents: Vec<String>,
+}
+
+#[derive(Deserialize, Debug)]
+struct EmbeddingResponse {
+    data: Vec<EmbeddingData>,
+}
+#[derive(Deserialize, Serialize, Debug)]
+struct EmbeddingData {
+    embedding: Vec<f32>,
+    index: usize,
+}
+
+invoke!(get_document_embeddings);
+fn get_document_embeddings(Json(body): Json<Request>) -> WebResult<WebResponse> {
+    setup_logging()?;
+
+    let data = get_embeddings(body.documents)?;
+    Ok(WebResponse::new().with_status(200).with_body(Json(data))?)
+}
+
+fn get_embeddings(mut documents: Vec<String>) -> WebResult<Vec<EmbeddingData>> {
+    log::debug!("getting embeddings for document with content: {documents:?}");
+    for document in &mut documents {
+        if document.contains('\n') {
+            // OpenAI's embeddings guide recommends replacing newlines with spaces.
+            // https://platform.openai.com/docs/guides/embeddings
+            *document = document.replace('\n', " ");
+        }
+    }
+
+    let openai_api_key = std::env::var("OPENAI_API_KEY").unwrap_or_default();
+    let response = http_invoke(
+        HttpRequest::new("https://api.openai.com/v1/embeddings", "POST")
+            .with_header("authorization", format!("Bearer {openai_api_key}"))
+            .with_header("content-type", "application/json")
+            .with_body(
+                serde_json::json!({
+                    "model": "text-embedding-3-small",
+                    "encoding_format": "float",
+                    "input": documents,
+                })
+                .to_string(),
+            ),
+    )?;
+    log::debug!("OpenAI response status: {}", response.status);
+
+    let Json(EmbeddingResponse { mut data }) = Json::<EmbeddingResponse>::extract(response.body)?;
+    data.sort_by_key(|d| d.index);
+    Ok(data)
+}
+
+fn setup_logging() -> WebResult<()> {
+    let env = WebEnvironment::load();
+    configure_logs([LogDestination::topic(env.function_name()).into()])?;
+    Ok(())
+}

--- a/examples/web-function-json-greeter/Cargo.toml
+++ b/examples/web-function-json-greeter/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "example-web-function-json-greeter"
+version = "0.0.0"
+edition.workspace = true
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+momento-functions-bytes     = { workspace = true }
+momento-functions-guest-web = { workspace = true }
+
+serde                       = { workspace = true }

--- a/examples/web-function-json-greeter/src/lib.rs
+++ b/examples/web-function-json-greeter/src/lib.rs
@@ -1,0 +1,19 @@
+use momento_functions_bytes::encoding::Json;
+use momento_functions_guest_web::invoke;
+
+#[derive(serde::Deserialize)]
+struct Request {
+    name: String,
+}
+
+#[derive(serde::Serialize)]
+struct Response {
+    message: String,
+}
+
+invoke!(greet);
+fn greet(Json(request): Json<Request>) -> Json<Response> {
+    Json(Response {
+        message: format!("Hello, {}!", request.name),
+    })
+}

--- a/examples/web-function-token-metadata/Cargo.toml
+++ b/examples/web-function-token-metadata/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "example-web-function-token-metadata"
+version = "0.0.0"
+edition.workspace = true
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+momento-functions-bytes     = { workspace = true }
+momento-functions-guest-web = { workspace = true }
+
+serde                       = { workspace = true }

--- a/examples/web-function-token-metadata/src/lib.rs
+++ b/examples/web-function-token-metadata/src/lib.rs
@@ -1,0 +1,24 @@
+//! Returns the caller's provided metadata from the `token_id` field of the
+//! Momento API key used to invoke this Function. When calling `GenerateApiToken`
+//! or `GenerateDisposableToken`, you can pass a stringified payload in `token_id`
+//! and retrieve it here.
+
+use momento_functions_bytes::{Data, encoding::Json};
+use momento_functions_guest_web::{WebEnvironment, invoke};
+
+#[derive(serde::Serialize)]
+struct Response {
+    message: String,
+}
+
+invoke!(token_metadata);
+fn token_metadata(_: Data) -> Json<Response> {
+    match WebEnvironment::load().token_metadata() {
+        Some(metadata) => Json(Response {
+            message: format!("Token metadata provided: {metadata}"),
+        }),
+        None => Json(Response {
+            message: "No metadata provided, try invoking with a Momento key that was generated with a populated 'token_id' field".to_string(),
+        }),
+    }
+}

--- a/examples/web-function/Cargo.toml
+++ b/examples/web-function/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "example-web-function"
+version = "0.0.0"
+edition.workspace = true
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+momento-functions-bytes     = { workspace = true }
+momento-functions-guest-web = { workspace = true }

--- a/examples/web-function/src/lib.rs
+++ b/examples/web-function/src/lib.rs
@@ -1,0 +1,7 @@
+use momento_functions_bytes::Data;
+use momento_functions_guest_web::invoke;
+
+invoke!(ping);
+fn ping(_payload: Data) -> &'static str {
+    "pong"
+}


### PR DESCRIPTION
Now that the necessary V2 crates are migrated, we can point new users to V2 functions instead. Showcases minimal examples of what we previously had, but in V2
