### PR TITLE
feat: properly port over metadata manipulation for v2 s3

### DIFF
--- a/aws-s3/src/client.rs
+++ b/aws-s3/src/client.rs
@@ -101,6 +101,16 @@ pub struct GetObjectResponse<T> {
     pub metadata: Vec<(String, String)>,
 }
 
+/// The response from a successful S3 put.
+pub struct PutObjectResponse {
+    /// Entity tag assigned by S3 to the stored object.
+    pub etag: Option<String>,
+    /// Version identifier assigned by S3 when bucket versioning is enabled.
+    pub version_id: Option<String>,
+    /// Expiration metadata returned by S3, when a lifecycle rule applies.
+    pub expiration: Option<String>,
+}
+
 impl S3Client {
     /// Create a new S3 client.
     pub fn new(credentials: &CredentialsProvider) -> Self {
@@ -114,12 +124,16 @@ impl S3Client {
     /// Build the request with [`PutObjectRequest::new`] and, if needed,
     /// [`PutObjectRequest::with_metadata`]. You can use strings, bytes, or
     /// structs that implement [`Encode`] as the body.
-    pub fn put<E: Encode>(&self, request: PutObjectRequest<E>) -> Result<(), S3PutError<E::Error>> {
+    pub fn put<E: Encode>(
+        &self,
+        request: PutObjectRequest<E>,
+    ) -> Result<PutObjectResponse, S3PutError<E::Error>> {
         let body_data: Data = request
             .body
             .try_serialize()
             .map_err(|e| S3PutError::EncodeFailed { cause: e })?;
-        self.client
+        let output = self
+            .client
             .put(aws_s3::PutObjectRequest {
                 bucket: request.bucket,
                 key: request.key,
@@ -127,7 +141,11 @@ impl S3Client {
                 metadata: request.metadata,
             })
             .map_err(S3PutError::from)?;
-        Ok(())
+        Ok(PutObjectResponse {
+            etag: output.etag,
+            version_id: output.version_id,
+            expiration: output.expiration,
+        })
     }
 
     /// Get an object from an S3 bucket along with its user-defined metadata.

--- a/aws-s3/src/client.rs
+++ b/aws-s3/src/client.rs
@@ -49,6 +49,58 @@ where
     S3Error(#[from] aws_s3::S3Error),
 }
 
+/// A request to put an object into an S3 bucket.
+///
+/// Construct with [`PutObjectRequest::new`] and add user-defined metadata
+/// via [`PutObjectRequest::with_metadata`] or
+/// [`PutObjectRequest::with_metadata_entry`].
+pub struct PutObjectRequest<E: Encode> {
+    bucket: String,
+    key: String,
+    body: E,
+    metadata: Vec<(String, String)>,
+}
+
+impl<E: Encode> PutObjectRequest<E> {
+    /// Create a new put request with no metadata.
+    pub fn new(bucket: impl Into<String>, key: impl Into<String>, body: E) -> Self {
+        Self {
+            bucket: bucket.into(),
+            key: key.into(),
+            body,
+            metadata: Vec::new(),
+        }
+    }
+
+    /// Attach user-defined metadata entries to the request.
+    ///
+    /// Entries are sent as `x-amz-meta-*` headers and stored alongside the
+    /// object. Existing entries are preserved; duplicate keys are not merged.
+    pub fn with_metadata<K, V>(mut self, metadata: impl IntoIterator<Item = (K, V)>) -> Self
+    where
+        K: Into<String>,
+        V: Into<String>,
+    {
+        self.metadata
+            .extend(metadata.into_iter().map(|(k, v)| (k.into(), v.into())));
+        self
+    }
+
+    /// Attach a single user-defined metadata entry to the request.
+    pub fn with_metadata_entry(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.metadata.push((key.into(), value.into()));
+        self
+    }
+}
+
+/// The response from a successful S3 get.
+pub struct GetObjectResponse<T> {
+    /// The decoded object body.
+    pub body: T,
+    /// User-defined metadata stored alongside the object.
+    pub metadata: Vec<(String, String)>,
+}
+
 impl S3Client {
     /// Create a new S3 client.
     pub fn new(credentials: &CredentialsProvider) -> Self {
@@ -59,34 +111,33 @@ impl S3Client {
 
     /// Put an object into an S3 bucket.
     ///
-    /// You can use strings, bytes, or structs that implement [`Encode`].
-    pub fn put<E: Encode>(
-        &self,
-        bucket: impl Into<String>,
-        key: impl Into<String>,
-        body: E,
-    ) -> Result<(), S3PutError<E::Error>> {
-        let body_data: Data = body
+    /// Build the request with [`PutObjectRequest::new`] and, if needed,
+    /// [`PutObjectRequest::with_metadata`]. You can use strings, bytes, or
+    /// structs that implement [`Encode`] as the body.
+    pub fn put<E: Encode>(&self, request: PutObjectRequest<E>) -> Result<(), S3PutError<E::Error>> {
+        let body_data: Data = request
+            .body
             .try_serialize()
             .map_err(|e| S3PutError::EncodeFailed { cause: e })?;
         self.client
             .put(aws_s3::PutObjectRequest {
-                bucket: bucket.into(),
-                key: key.into(),
+                bucket: request.bucket,
+                key: request.key,
                 body: body_data.into(),
+                metadata: request.metadata,
             })
             .map_err(S3PutError::from)?;
         Ok(())
     }
 
-    /// Get an object from an S3 bucket.
+    /// Get an object from an S3 bucket along with its user-defined metadata.
     ///
     /// Returns `Ok(None)` if the object was not found.
     pub fn get<T: Extract>(
         &self,
         bucket: impl Into<String>,
         key: impl Into<String>,
-    ) -> Result<Option<T>, S3GetError<T::Error>> {
+    ) -> Result<Option<GetObjectResponse<T>>, S3GetError<T::Error>> {
         let output = self
             .client
             .get(&aws_s3::GetObjectRequest {
@@ -97,7 +148,12 @@ impl S3Client {
         if let Some(wit_data) = output.body {
             let data: Data = wit_data.into();
             T::extract(data)
-                .map(Some)
+                .map(|body| {
+                    Some(GetObjectResponse {
+                        body,
+                        metadata: output.metadata,
+                    })
+                })
                 .map_err(|e| S3GetError::ExtractFailed { cause: e })
         } else {
             Ok(None)

--- a/aws-s3/src/lib.rs
+++ b/aws-s3/src/lib.rs
@@ -13,7 +13,9 @@ mod client;
 #[doc(hidden)]
 pub mod wit;
 
-pub use client::{GetObjectResponse, PutObjectRequest, S3Client, S3GetError, S3PutError};
+pub use client::{
+    GetObjectResponse, PutObjectRequest, PutObjectResponse, S3Client, S3GetError, S3PutError,
+};
 
 pub use momento_functions_aws_auth::{
     AuthError, Authorization, Credentials, CredentialsProvider, IamRole, provider,

--- a/aws-s3/src/lib.rs
+++ b/aws-s3/src/lib.rs
@@ -13,7 +13,7 @@ mod client;
 #[doc(hidden)]
 pub mod wit;
 
-pub use client::{S3Client, S3GetError, S3PutError};
+pub use client::{GetObjectResponse, PutObjectRequest, S3Client, S3GetError, S3PutError};
 
 pub use momento_functions_aws_auth::{
     AuthError, Authorization, Credentials, CredentialsProvider, IamRole, provider,

--- a/aws-s3/wit/aws-s3.wit
+++ b/aws-s3/wit/aws-s3.wit
@@ -17,6 +17,7 @@ interface aws-s3 {
      bucket: string,
      key: string,
      body: data,
+     metadata: list<tuple<string, string>>,
    }
 
    record put-object-output {
@@ -35,6 +36,7 @@ interface aws-s3 {
      etag: option<string>,
      version-id: option<string>,
      expiration: option<string>,
+     metadata: list<tuple<string, string>>,
    }
 
    resource client {

--- a/examples/s3-get/src/lib.rs
+++ b/examples/s3-get/src/lib.rs
@@ -15,6 +15,8 @@ struct Request {
 #[derive(Debug, Serialize)]
 struct Response {
     message: String,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    metadata: Vec<(String, String)>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -41,32 +43,40 @@ fn s3_get(Json(request): Json<Request>) -> WebResult<WebResponse> {
         &request.bucket,
         &request.key
     );
-    let response: MyStructure = match client.get(&request.bucket, &request.key) {
-        Ok(Some(Json(r))) => r,
-        Ok(None) => {
-            return Ok(WebResponse::new()
-                .with_status(404)
-                .with_body(Json(Response {
-                    message: "Not found".to_string(),
-                }))?);
-        }
-        Err(e) => {
-            return Ok(WebResponse::new()
-                .with_status(500)
-                .with_body(Json(Response {
-                    message: format!("Failed to get object from S3: {e:?}"),
-                }))?);
-        }
-    };
+    let (response, metadata): (MyStructure, Vec<(String, String)>) =
+        match client.get(&request.bucket, &request.key) {
+            Ok(Some(r)) => {
+                let Json(value) = r.body;
+                (value, r.metadata)
+            }
+            Ok(None) => {
+                return Ok(WebResponse::new()
+                    .with_status(404)
+                    .with_body(Json(Response {
+                        message: "Not found".to_string(),
+                        metadata: Vec::new(),
+                    }))?);
+            }
+            Err(e) => {
+                return Ok(WebResponse::new()
+                    .with_status(500)
+                    .with_body(Json(Response {
+                        message: format!("Failed to get object from S3: {e:?}"),
+                        metadata: Vec::new(),
+                    }))?);
+            }
+        };
 
     log::info!(
-        "found response with a_number: {}, a_string: {}",
+        "found response with a_number: {}, a_string: {}, metadata entries: {}",
         response.a_number,
-        response.a_string
+        response.a_string,
+        metadata.len()
     );
     Ok(WebResponse::new()
         .with_status(200)
         .with_body(Json(Response {
             message: format!("Found: {response:?}"),
+            metadata,
         }))?)
 }

--- a/examples/s3-put/src/lib.rs
+++ b/examples/s3-put/src/lib.rs
@@ -1,5 +1,5 @@
 use momento_functions_aws_auth::{Authorization, IamRole, provider};
-use momento_functions_aws_s3::S3Client;
+use momento_functions_aws_s3::{PutObjectRequest, S3Client};
 use momento_functions_bytes::encoding::Json;
 use momento_functions_guest_web::{WebEnvironment, WebResponse, WebResult, invoke};
 use momento_functions_host_log::{LogDestination, configure_logs};
@@ -11,6 +11,8 @@ struct Request {
     bucket: String,
     key: String,
     value: String,
+    #[serde(default)]
+    metadata: Vec<(String, String)>,
 }
 
 #[derive(Debug, Serialize)]
@@ -45,12 +47,15 @@ fn s3_put(Json(request): Json<Request>) -> WebResult<WebResponse> {
     );
 
     if let Err(e) = client.put(
-        &request.bucket,
-        &request.key,
-        Json(MyStructure {
-            a_number: 42,
-            a_string: request.value,
-        }),
+        PutObjectRequest::new(
+            &request.bucket,
+            &request.key,
+            Json(MyStructure {
+                a_number: 42,
+                a_string: request.value,
+            }),
+        )
+        .with_metadata(request.metadata),
     ) {
         return Ok(WebResponse::new()
             .with_status(500)

--- a/examples/s3-put/src/lib.rs
+++ b/examples/s3-put/src/lib.rs
@@ -18,6 +18,12 @@ struct Request {
 #[derive(Debug, Serialize)]
 struct Response {
     message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    etag: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    version_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    expiration: Option<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -46,7 +52,7 @@ fn s3_put(Json(request): Json<Request>) -> WebResult<WebResponse> {
         &request.value.len()
     );
 
-    if let Err(e) = client.put(
+    let put_response = match client.put(
         PutObjectRequest::new(
             &request.bucket,
             &request.key,
@@ -57,16 +63,31 @@ fn s3_put(Json(request): Json<Request>) -> WebResult<WebResponse> {
         )
         .with_metadata(request.metadata),
     ) {
-        return Ok(WebResponse::new()
-            .with_status(500)
-            .with_body(Json(Response {
-                message: format!("Failed to put object {e:?}"),
-            }))?);
-    }
+        Ok(response) => response,
+        Err(e) => {
+            return Ok(WebResponse::new()
+                .with_status(500)
+                .with_body(Json(Response {
+                    message: format!("Failed to put object {e:?}"),
+                    etag: None,
+                    version_id: None,
+                    expiration: None,
+                }))?);
+        }
+    };
+
+    log::info!(
+        "put object succeeded, etag: {:?}, version_id: {:?}",
+        put_response.etag,
+        put_response.version_id,
+    );
 
     Ok(WebResponse::new()
         .with_status(200)
         .with_body(Json(Response {
             message: "Successfully put object".to_string(),
+            etag: put_response.etag,
+            version_id: put_response.version_id,
+            expiration: put_response.expiration,
         }))?)
 }


### PR DESCRIPTION
_This is a breaking change for any existing consumers_.

When we ported over AWS S3 V2, we didn't properly port over some of the `.wit` definitions we had intended to have from day 0 for v2. With these changes, we can make the S3 interaction a bit more user-friendly without helper functions, etc. Updated the examples.
