### PR TITLE
feat: add support for request timeout duration with the http client

### DIFF
--- a/http/src/invoke.rs
+++ b/http/src/invoke.rs
@@ -99,7 +99,15 @@ impl From<http::Response> for Response {
 /// }
 /// ```
 pub fn invoke(request: Request) -> Result<Response, HttpError> {
-    http::invoke(request.into())
-        .map(Into::into)
-        .map_err(Into::into)
+    match request.request_timeout() {
+        // Saturate rather than wrap: a duration beyond u64::MAX ms is still an
+        // effectively-unbounded timeout, so clamping to the max is the safe read.
+        Some(timeout) => {
+            let timeout_milliseconds = u64::try_from(timeout.as_millis()).unwrap_or(u64::MAX);
+            http::invoke_with_timeout(request.into(), timeout_milliseconds)
+        }
+        None => http::invoke(request.into()),
+    }
+    .map(Into::into)
+    .map_err(Into::into)
 }

--- a/http/src/request.rs
+++ b/http/src/request.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use momento_functions_bytes::{
     Data,
     encoding::{Encode, Json},
@@ -74,6 +76,7 @@ pub struct Request {
     headers: Vec<(String, String)>,
     body: Data,
     authorization: Authorization,
+    request_timeout: Option<Duration>,
 }
 
 impl Request {
@@ -94,6 +97,7 @@ impl Request {
             headers: Vec::new(),
             body: Data::from(vec![]),
             authorization: Authorization::None,
+            request_timeout: None,
         }
     }
 
@@ -173,6 +177,30 @@ impl Request {
     pub fn with_authorization(mut self, authorization: Authorization) -> Self {
         self.authorization = authorization;
         self
+    }
+
+    /// Set a total timeout for the request. If the whole request — connecting,
+    /// sending, and receiving the full response — does not complete within this
+    /// duration, it fails with a timeout error. The duration is converted to
+    /// whole milliseconds when handed to the host.
+    ///
+    /// # Examples
+    /// ________
+    /// ```rust,no_run
+    /// use std::time::Duration;
+    /// use momento_functions_http::Request;
+    ///
+    /// let request = Request::new("https://example.com/api", "GET")
+    ///     .with_request_timeout(Duration::from_secs(5));
+    /// ```
+    pub fn with_request_timeout(mut self, timeout: Duration) -> Self {
+        self.request_timeout = Some(timeout);
+        self
+    }
+
+    /// The configured total request timeout, if any.
+    pub(crate) fn request_timeout(&self) -> Option<Duration> {
+        self.request_timeout
     }
 }
 

--- a/http/wit/http.wit
+++ b/http/wit/http.wit
@@ -70,6 +70,8 @@ interface http {
 
     /// Send a web request
     invoke: func(request: request) -> result<response, error>;
+    /// Send a web request with a total per-request timeout, in milliseconds.
+    invoke-with-timeout: func(request: request, timeout-milliseconds: u64) -> result<response, error>;
 }
 
 world imports {


### PR DESCRIPTION
Adds support for a `.with_timeout` call for HTTP requests. This is for the entire lifecycle of the request (connection establishment, actual request dispatch, etc.),
but makes it easier for consumers to write HTTP calls that will bail out early without hitting a function's max execution time.
