### PR TITLE
feat(aws-ddb): add query to the DynamoDB host interface

### DIFF
--- a/aws-ddb/src/client.rs
+++ b/aws-ddb/src/client.rs
@@ -1,7 +1,8 @@
-use crate::types::{Item, Key};
+use crate::types::{AttributeValue, Item, Key};
 use crate::wit::momento::aws_ddb::aws_ddb::{self as aws_ddb};
 use momento_functions_aws_auth::CredentialsProvider;
 use momento_functions_bytes::Data;
+use std::collections::HashMap;
 
 /// DynamoDB client for host interfaces.
 ///
@@ -211,5 +212,221 @@ impl DynamoDBClient {
         })?;
 
         Ok(())
+    }
+
+    /// Query a table or a secondary index — ONE page of results.
+    ///
+    /// Unlike [`get_item_raw`](Self::get_item_raw), this is a paginated call: DynamoDB stops at
+    /// `limit` or at its 1 MB page cap, whichever comes first. Check
+    /// [`QueryPage::last_evaluated_key`] and pass it back via [`Query::start_after`] to continue.
+    /// **A page can be empty while more results remain** (everything in it was filtered out), so
+    /// looping on "items is empty" instead of on the key silently truncates the result set.
+    ///
+    /// Examples:
+    /// ________
+    /// One page:
+    /// ```rust,no_run
+    /// use momento_functions_aws_ddb::{DynamoDBClient, DynamoDBError, Query};
+    ///
+    /// # fn recent_for(client: &DynamoDBClient, id: &str) -> Result<(), DynamoDBError> {
+    /// let page = client.query(
+    ///     Query::new("my_table", "pk = :id")
+    ///         .index("my_index")
+    ///         .value(":id", id)
+    ///         .limit(100),
+    /// )?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    /// ________
+    /// Every page — the shape a total (a count, a sum) must use to be correct:
+    /// ```rust,no_run
+    /// # use momento_functions_aws_ddb::{DynamoDBClient, DynamoDBError, Item, Query};
+    /// # fn all_for(client: &DynamoDBClient, id: &str) -> Result<Vec<Item>, DynamoDBError> {
+    /// let mut all = Vec::new();
+    /// let mut start_key = None;
+    /// loop {
+    ///     let mut query = Query::new("my_table", "pk = :id").value(":id", id);
+    ///     if let Some(key) = start_key {
+    ///         query = query.start_after(key);
+    ///     }
+    ///     let page = client.query(query)?;
+    ///     all.extend(page.items);
+    ///     start_key = page.last_evaluated_key;
+    ///     if start_key.is_none() {
+    ///         break;
+    ///     }
+    /// }
+    /// # Ok(all)
+    /// # }
+    /// ```
+    pub fn query(&self, query: Query) -> Result<QueryPage, DynamoDBError> {
+        let Query {
+            table_name,
+            index_name,
+            key_condition_expression,
+            expression_attribute_values,
+            expression_attribute_names,
+            filter_expression,
+            projection_expression,
+            limit,
+            scan_index_forward,
+            consistent_read,
+            exclusive_start_key,
+        } = query;
+
+        let expression_attribute_values = match expression_attribute_values {
+            Some(attributes) => Some(aws_ddb::Item::Json(
+                Data::from(serde_json::to_vec(&Item { attributes })?).into(),
+            )),
+            None => None,
+        };
+
+        let output = self.client.query(aws_ddb::QueryRequest {
+            table_name,
+            index_name,
+            key_condition_expression,
+            expression_attribute_values,
+            expression_attribute_names,
+            filter_expression,
+            projection_expression,
+            limit,
+            scan_index_forward,
+            consistent_read,
+            exclusive_start_key,
+            return_consumed_capacity: aws_ddb::ReturnConsumedCapacity::None,
+        })?;
+
+        let mut items = Vec::with_capacity(output.items.len());
+        for item in output.items {
+            match item {
+                aws_ddb::Item::Json(data) => {
+                    let bytes = Data::from(data).into_bytes();
+                    items.push(serde_json::from_slice(&bytes)?);
+                }
+            }
+        }
+
+        Ok(QueryPage {
+            items,
+            count: output.count,
+            scanned_count: output.scanned_count,
+            last_evaluated_key: output.last_evaluated_key,
+        })
+    }
+}
+
+/// One page of a [`DynamoDBClient::query`].
+#[derive(Debug)]
+pub struct QueryPage {
+    /// The matching items, in sort-key order. May be empty while [`Self::last_evaluated_key`] is
+    /// `Some` — that page was entirely filtered out, which is NOT the end of the result set.
+    pub items: Vec<Item>,
+    /// Items returned in this page (after any filter expression).
+    pub count: u32,
+    /// Items evaluated in this page (before any filter expression).
+    pub scanned_count: u32,
+    /// `Some` when more pages remain — pass it to [`Query::start_after`]. `None` means complete.
+    pub last_evaluated_key: Option<Vec<aws_ddb::KeyAttribute>>,
+}
+
+/// A DynamoDB query. Built fluently; `table_name` and the key-condition expression are required
+/// because a query without them is not expressible.
+#[derive(Debug)]
+pub struct Query {
+    table_name: String,
+    index_name: Option<String>,
+    key_condition_expression: String,
+    expression_attribute_values: Option<HashMap<String, AttributeValue>>,
+    expression_attribute_names: Option<Vec<(String, String)>>,
+    filter_expression: Option<String>,
+    projection_expression: Option<String>,
+    limit: Option<u32>,
+    scan_index_forward: Option<bool>,
+    consistent_read: bool,
+    exclusive_start_key: Option<Vec<aws_ddb::KeyAttribute>>,
+}
+
+impl Query {
+    /// A query over `table_name` constrained by `key_condition_expression` (e.g. `"pk = :id"`).
+    /// Bind every `:placeholder` it references with [`value`](Self::value).
+    pub fn new(table_name: impl Into<String>, key_condition_expression: impl Into<String>) -> Self {
+        Query {
+            table_name: table_name.into(),
+            index_name: None,
+            key_condition_expression: key_condition_expression.into(),
+            expression_attribute_values: None,
+            expression_attribute_names: None,
+            filter_expression: None,
+            projection_expression: None,
+            limit: None,
+            scan_index_forward: None,
+            consistent_read: false,
+            exclusive_start_key: None,
+        }
+    }
+
+    /// Query a secondary index instead of the base table.
+    pub fn index(mut self, index_name: impl Into<String>) -> Self {
+        self.index_name = Some(index_name.into());
+        self
+    }
+
+    /// Bind one `:placeholder` used by the key condition or filter, e.g.
+    /// `.value(":id", ("S", "abc"))`.
+    pub fn value(
+        mut self,
+        placeholder: impl Into<String>,
+        value: impl Into<AttributeValue>,
+    ) -> Self {
+        self.expression_attribute_values
+            .get_or_insert_with(HashMap::new)
+            .insert(placeholder.into(), value.into());
+        self
+    }
+
+    /// Alias a reserved word used in an expression, e.g. `.name("#n", "name")`.
+    pub fn name(mut self, placeholder: impl Into<String>, attribute: impl Into<String>) -> Self {
+        self.expression_attribute_names
+            .get_or_insert_with(Vec::new)
+            .push((placeholder.into(), attribute.into()));
+        self
+    }
+
+    /// Filter results server-side AFTER the key condition. Does not reduce read cost — see the
+    /// `filter-expression` note on the host interface.
+    pub fn filter(mut self, filter_expression: impl Into<String>) -> Self {
+        self.filter_expression = Some(filter_expression.into());
+        self
+    }
+
+    /// Return only these attributes.
+    pub fn project(mut self, projection_expression: impl Into<String>) -> Self {
+        self.projection_expression = Some(projection_expression.into());
+        self
+    }
+
+    /// Cap items EVALUATED per page (before the filter), not items returned.
+    pub fn limit(mut self, limit: u32) -> Self {
+        self.limit = Some(limit);
+        self
+    }
+
+    /// Walk the sort key in descending order (newest-first, for a timestamp sort key).
+    pub fn descending(mut self) -> Self {
+        self.scan_index_forward = Some(false);
+        self
+    }
+
+    /// Read strongly-consistently. Invalid against a global secondary index.
+    pub fn consistent_read(mut self) -> Self {
+        self.consistent_read = true;
+        self
+    }
+
+    /// Continue from a previous page's [`QueryPage::last_evaluated_key`].
+    pub fn start_after(mut self, exclusive_start_key: Vec<aws_ddb::KeyAttribute>) -> Self {
+        self.exclusive_start_key = Some(exclusive_start_key);
+        self
     }
 }

--- a/aws-ddb/src/lib.rs
+++ b/aws-ddb/src/lib.rs
@@ -1,6 +1,6 @@
 //! Host interfaces for working with AWS DynamoDB.
 //!
-//! This crate provides a [`DynamoDBClient`] for putting and getting items in DynamoDB,
+//! This crate provides a [`DynamoDBClient`] for putting, getting and querying items in DynamoDB,
 //! using Momento's host-provided AWS communication channel.
 
 mod client;
@@ -10,7 +10,7 @@ mod types;
 #[doc(hidden)]
 pub mod wit;
 
-pub use client::{DynamoDBClient, DynamoDBError, GetItemError};
+pub use client::{DynamoDBClient, DynamoDBError, GetItemError, Query, QueryPage};
 pub use types::{
     AttributeValue, BinaryConversionError, ConversionError, Item, Key, KeyValue,
     NumericConversionError,

--- a/aws-ddb/wit/aws-ddb.wit
+++ b/aws-ddb/wit/aws-ddb.wit
@@ -92,10 +92,57 @@ interface aws-ddb {
         consumed-capacity: option<consumed-capacity>,
     }
 
+    record query-request {
+        table-name: string,
+        /// Query a secondary index instead of the base table. `none` queries the table itself.
+        /// A global secondary index is eventually consistent, so `consistent-read` must be false
+        /// when this names one.
+        index-name: option<string>,
+        /// Required. Constrains the partition key and optionally the sort key, e.g.
+        /// `"pk = :id AND sk BETWEEN :lo AND :hi"`. Only KEY attributes may appear here —
+        /// everything else belongs in `filter-expression`.
+        key-condition-expression: string,
+        /// Placeholder values the expressions reference, as a dynamodb-json item whose keys are the
+        /// `:name` placeholders — e.g. `{":id": {"S": "abc"}, ":lo": {"N": "17"}}`.
+        expression-attribute-values: option<item>,
+        expression-attribute-names: option<list<tuple<string, string>>>,
+        /// Applied AFTER the key condition, on the server. It reduces what is RETURNED, never what
+        /// is READ — a filtered-out item still costs read capacity and still counts toward the 1 MB
+        /// page cap, so a selective filter can yield an EMPTY page that still carries a
+        /// `last-evaluated-key`.
+        filter-expression: option<string>,
+        projection-expression: option<string>,
+        /// Cap on items EVALUATED per page (before `filter-expression`), not on items returned.
+        limit: option<u32>,
+        /// Sort-key order: `none` / `some(true)` ascending, `some(false)` descending.
+        scan-index-forward: option<bool>,
+        /// Invalid when `index-name` names a global secondary index.
+        consistent-read: bool,
+        /// Resume a paginated query: pass the previous page's `last-evaluated-key` verbatim.
+        exclusive-start-key: option<list<key-attribute>>,
+        return-consumed-capacity: return-consumed-capacity,
+    }
+    record query-output {
+        /// The matching items, in sort-key order. May be EMPTY while `last-evaluated-key` is set —
+        /// that means "this page was entirely filtered out", NOT "no more results". A caller
+        /// collecting a complete result set must loop until `last-evaluated-key` is `none`.
+        items: list<item>,
+        /// Items returned in this page (after `filter-expression`).
+        count: u32,
+        /// Items evaluated in this page (before `filter-expression`). Equals `count` when no filter
+        /// is set; a large gap means the query reads far more than it returns.
+        scanned-count: u32,
+        /// `some` when the page stopped early — at `limit`, or at DynamoDB's 1 MB page cap. Feed it
+        /// back as `exclusive-start-key` to continue. `none` means the result set is complete.
+        last-evaluated-key: option<list<key-attribute>>,
+        consumed-capacity: option<consumed-capacity>,
+    }
+
     resource client {
         constructor(credentials: borrow<credentials-provider>);
         put-item: func(request: put-item-request) -> result<put-item-output, ddb-error>;
         get-item: func(request: get-item-request) -> result<get-item-output, ddb-error>;
+        query: func(request: query-request) -> result<query-output, ddb-error>;
     }
 }
 

--- a/momento-functions-host/src/aws/ddb.rs
+++ b/momento-functions-host/src/aws/ddb.rs
@@ -230,6 +230,204 @@ impl DynamoDBClient {
 
         Ok(())
     }
+
+    /// Query a table or a secondary index — ONE page of results.
+    ///
+    /// Unlike [`get_item`](Self::get_item), this is a paginated call: DynamoDB stops at the query's
+    /// `limit` or at its own 1 MB page cap, whichever comes first. Check
+    /// [`QueryPage::last_evaluated_key`] and pass it back via [`Query::start_after`] to continue.
+    ///
+    /// **A page can be empty while more results remain** — a filter is applied after the key
+    /// condition, so an entire page can be filtered out. Loop until `last_evaluated_key` is `None`;
+    /// looping on "items is empty" silently truncates the result set.
+    ///
+    /// ```rust,no_run
+    /// use momento_functions_host::aws::ddb::{DynamoDBClient, DynamoDBError, Item, Query};
+    ///
+    /// /// Every item under one partition of a secondary index, across all pages.
+    /// fn all_for(client: &DynamoDBClient, id: &str) -> Result<Vec<Item>, DynamoDBError> {
+    ///     let mut all = Vec::new();
+    ///     let mut start_key = None;
+    ///     loop {
+    ///         let mut query = Query::new("my_table", "pk = :id")
+    ///             .index("my_index")
+    ///             .value(":id", id);
+    ///         if let Some(key) = start_key {
+    ///             query = query.start_after(key);
+    ///         }
+    ///         let page = client.query(query)?;
+    ///         all.extend(page.items);
+    ///         start_key = page.last_evaluated_key;
+    ///         if start_key.is_none() {
+    ///             return Ok(all);
+    ///         }
+    ///     }
+    /// }
+    /// ```
+    pub fn query(&self, query: Query) -> Result<QueryPage, DynamoDBError> {
+        let Query {
+            table_name,
+            index_name,
+            key_condition_expression,
+            expression_attribute_values,
+            expression_attribute_names,
+            filter_expression,
+            projection_expression,
+            limit,
+            scan_index_forward,
+            consistent_read,
+            exclusive_start_key,
+        } = query;
+
+        let expression_attribute_values = match expression_attribute_values {
+            Some(attributes) => Some(host::aws_ddb::Item::Json(serde_json::to_string(&Item {
+                attributes,
+            })?)),
+            None => None,
+        };
+
+        let output = self.client.query(&host::aws_ddb::QueryRequest {
+            table_name,
+            index_name,
+            key_condition_expression,
+            expression_attribute_values,
+            expression_attribute_names,
+            filter_expression,
+            projection_expression,
+            limit,
+            scan_index_forward,
+            consistent_read,
+            exclusive_start_key,
+            return_consumed_capacity: host::aws_ddb::ReturnConsumedCapacity::None,
+        })?;
+
+        let mut items = Vec::with_capacity(output.items.len());
+        for item in output.items {
+            match item {
+                host::aws_ddb::Item::Json(json) => items.push(serde_json::from_str(&json)?),
+            }
+        }
+
+        Ok(QueryPage {
+            items,
+            count: output.count,
+            scanned_count: output.scanned_count,
+            last_evaluated_key: output.last_evaluated_key,
+        })
+    }
+}
+
+/// One page of a [`DynamoDBClient::query`].
+#[derive(Debug)]
+pub struct QueryPage {
+    /// The matching items, in sort-key order. May be empty while [`Self::last_evaluated_key`] is
+    /// `Some` — that page was entirely filtered out, which is NOT the end of the result set.
+    pub items: Vec<Item>,
+    /// Items returned in this page (after any filter expression).
+    pub count: u32,
+    /// Items evaluated in this page (before any filter expression).
+    pub scanned_count: u32,
+    /// `Some` when more pages remain — pass it to [`Query::start_after`]. `None` means complete.
+    pub last_evaluated_key: Option<Vec<host::aws_ddb::KeyAttribute>>,
+}
+
+/// A DynamoDB query. The table and the key-condition expression are required; everything else is
+/// optional and set fluently.
+#[derive(Debug)]
+pub struct Query {
+    table_name: String,
+    index_name: Option<String>,
+    key_condition_expression: String,
+    expression_attribute_values: Option<HashMap<String, AttributeValue>>,
+    expression_attribute_names: Option<Vec<(String, String)>>,
+    filter_expression: Option<String>,
+    projection_expression: Option<String>,
+    limit: Option<u32>,
+    scan_index_forward: Option<bool>,
+    consistent_read: bool,
+    exclusive_start_key: Option<Vec<host::aws_ddb::KeyAttribute>>,
+}
+
+impl Query {
+    /// A query over `table_name` constrained by `key_condition_expression` (e.g. `"pk = :id"`).
+    /// Bind every `:placeholder` it references with [`value`](Self::value).
+    pub fn new(table_name: impl Into<String>, key_condition_expression: impl Into<String>) -> Self {
+        Query {
+            table_name: table_name.into(),
+            index_name: None,
+            key_condition_expression: key_condition_expression.into(),
+            expression_attribute_values: None,
+            expression_attribute_names: None,
+            filter_expression: None,
+            projection_expression: None,
+            limit: None,
+            scan_index_forward: None,
+            consistent_read: false,
+            exclusive_start_key: None,
+        }
+    }
+
+    /// Query a secondary index instead of the base table.
+    pub fn index(mut self, index_name: impl Into<String>) -> Self {
+        self.index_name = Some(index_name.into());
+        self
+    }
+
+    /// Bind one `:placeholder` used by the key condition or the filter.
+    pub fn value(
+        mut self,
+        placeholder: impl Into<String>,
+        value: impl Into<AttributeValue>,
+    ) -> Self {
+        self.expression_attribute_values
+            .get_or_insert_with(HashMap::new)
+            .insert(placeholder.into(), value.into());
+        self
+    }
+
+    /// Alias a reserved word used in an expression, e.g. `.name("#n", "name")`.
+    pub fn name(mut self, placeholder: impl Into<String>, attribute: impl Into<String>) -> Self {
+        self.expression_attribute_names
+            .get_or_insert_with(Vec::new)
+            .push((placeholder.into(), attribute.into()));
+        self
+    }
+
+    /// Filter results server-side AFTER the key condition. Does not reduce read cost.
+    pub fn filter(mut self, filter_expression: impl Into<String>) -> Self {
+        self.filter_expression = Some(filter_expression.into());
+        self
+    }
+
+    /// Return only these attributes.
+    pub fn project(mut self, projection_expression: impl Into<String>) -> Self {
+        self.projection_expression = Some(projection_expression.into());
+        self
+    }
+
+    /// Cap items EVALUATED per page (before the filter), not items returned.
+    pub fn limit(mut self, limit: u32) -> Self {
+        self.limit = Some(limit);
+        self
+    }
+
+    /// Walk the sort key in descending order (newest-first, for a timestamp sort key).
+    pub fn descending(mut self) -> Self {
+        self.scan_index_forward = Some(false);
+        self
+    }
+
+    /// Read strongly-consistently. Invalid against a global secondary index.
+    pub fn consistent_read(mut self) -> Self {
+        self.consistent_read = true;
+        self
+    }
+
+    /// Continue from a previous page's [`QueryPage::last_evaluated_key`].
+    pub fn start_after(mut self, exclusive_start_key: Vec<host::aws_ddb::KeyAttribute>) -> Self {
+        self.exclusive_start_key = Some(exclusive_start_key);
+        self
+    }
 }
 
 /// DynamoDB key type

--- a/momento-functions-wit/wit/host/aws-ddb.wit
+++ b/momento-functions-wit/wit/host/aws-ddb.wit
@@ -91,9 +91,56 @@ interface aws-ddb {
         consumed-capacity: option<consumed-capacity>,
     }
 
+    record query-request {
+        table-name: string,
+        /// Query a secondary index instead of the base table. `none` queries the table itself.
+        /// A global secondary index is eventually consistent, so `consistent-read` must be false
+        /// when this names one.
+        index-name: option<string>,
+        /// Required. Constrains the partition key and optionally the sort key, e.g.
+        /// `"pk = :id AND sk BETWEEN :lo AND :hi"`. Only KEY attributes may appear here —
+        /// everything else belongs in `filter-expression`.
+        key-condition-expression: string,
+        /// Placeholder values the expressions reference, as a dynamodb-json item whose keys are the
+        /// `:name` placeholders — e.g. `{":id": {"S": "abc"}, ":lo": {"N": "17"}}`.
+        expression-attribute-values: option<item>,
+        expression-attribute-names: option<list<tuple<string, string>>>,
+        /// Applied AFTER the key condition, on the server. It reduces what is RETURNED, never what
+        /// is READ — a filtered-out item still costs read capacity and still counts toward the 1 MB
+        /// page cap, so a selective filter can yield an EMPTY page that still carries a
+        /// `last-evaluated-key`.
+        filter-expression: option<string>,
+        projection-expression: option<string>,
+        /// Cap on items EVALUATED per page (before `filter-expression`), not on items returned.
+        limit: option<u32>,
+        /// Sort-key order: `none` / `some(true)` ascending, `some(false)` descending.
+        scan-index-forward: option<bool>,
+        /// Invalid when `index-name` names a global secondary index.
+        consistent-read: bool,
+        /// Resume a paginated query: pass the previous page's `last-evaluated-key` verbatim.
+        exclusive-start-key: option<list<key-attribute>>,
+        return-consumed-capacity: return-consumed-capacity,
+    }
+    record query-output {
+        /// The matching items, in sort-key order. May be EMPTY while `last-evaluated-key` is set —
+        /// that means "this page was entirely filtered out", NOT "no more results". A caller
+        /// collecting a complete result set must loop until `last-evaluated-key` is `none`.
+        items: list<item>,
+        /// Items returned in this page (after `filter-expression`).
+        count: u32,
+        /// Items evaluated in this page (before `filter-expression`). Equals `count` when no filter
+        /// is set; a large gap means the query reads far more than it returns.
+        scanned-count: u32,
+        /// `some` when the page stopped early — at `limit`, or at DynamoDB's 1 MB page cap. Feed it
+        /// back as `exclusive-start-key` to continue. `none` means the result set is complete.
+        last-evaluated-key: option<list<key-attribute>>,
+        consumed-capacity: option<consumed-capacity>,
+    }
+
     resource client {
         constructor(credentials: borrow<credentials-provider>);
         put-item: func(request: put-item-request) -> result<put-item-output, ddb-error>;
         get-item: func(request: get-item-request) -> result<get-item-output, ddb-error>;
+        query: func(request: query-request) -> result<query-output, ddb-error>;
     }
 }


### PR DESCRIPTION
**Adds `query` to the DynamoDB host interface — the guest half. Inert until the matching host implementation ships (momentohq/mr2rs#3368).**

## Why

A Function can put and get single items, but has no way to read a secondary index — so any aggregate over a partition (a per-key rollup, a time window, a list-under-X) is unreachable from wasm. The alternative is routing the read through a Lambda: a second deployed component and a synchronous hop for something DynamoDB does natively. This is the one CRUD verb the interface is missing.

## What

Both live generations, because both have consumers:

- **v1** (unversioned, `item = json(string)`) — `momento-functions-wit/wit/host/aws-ddb.wit` + `momento-functions-host/src/aws/ddb.rs`.
- **v2** (`momento:aws-ddb@1.0.0`, `item = json(data)`) — `aws-ddb/wit/aws-ddb.wit` + `aws-ddb/src/client.rs`.

Each wrapper exposes a fluent `Query` builder and a `QueryPage` result rather than an eleven-parameter function, so a call site reads by field instead of by position.

### Pagination is part of the contract

`QueryPage` carries `last_evaluated_key`; `Query::start_after` takes it back. This is deliberate and it's the part worth reviewing: without a cursor a Query stops at DynamoDB's 1 MB page cap and the caller cannot tell a complete answer from a truncated one. For a sum or a count that's a plausible-looking wrong number, not an error.

The doc-tests on both wrappers demonstrate the full paging loop, and both call out the trap that follows: **a page can be empty while more results remain** (a `filter` is applied after the key condition), so the loop must terminate on `last_evaluated_key == None` and never on `items.is_empty()`.

## Verification

- [x] `cargo check --workspace` — clean.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- [x] `cargo test` on the native target — **9 passing in `momento-functions-aws-ddb`** (baseline on `main` is 7; the two new ones are the `query` doc-tests) and **77 in `momento-functions-host`**.
  (`cargo test --workspace` on the default target fails to *execute* the wasm example crates — pre-existing and environmental, unrelated to this change.)
- [ ] End-to-end exercise of `query` waits on the host implementation; the wasm integration test lives in the mr2rs PR.

## Rollout

Host first. A component's imports resolve at **instantiation**, so a guest importing `query` that reaches a cell running older host code fails to instantiate — a total outage for that Function, not a call-time error. Nothing should bump to a release carrying this until the host side has reached the fleet.
