### PR TITLE
chore: retire the machine-user release token

### DIFF
--- a/.github/workflows/on-push-to-main.yml
+++ b/.github/workflows/on-push-to-main.yml
@@ -14,16 +14,25 @@ jobs:
     name: Release Please
     runs-on: ubuntu-latest
     steps:
+      - name: Generate release bot token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.MOMENTO_RELEASE_APP_ID }}
+          private-key: ${{ secrets.MOMENTO_RELEASE_APP_PRIVATE_KEY }}
+
       - uses: googleapis/release-please-action@v4
         id: release
         with:
-          token: ${{ secrets.MOMENTO_MACHINE_USER_GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - uses: actions/checkout@v4
         if: ${{ steps.release.outputs.pr != '' }}
         with:
           ref: ${{ steps.release.outputs.pr != '' && fromJSON(steps.release.outputs.pr).headBranchName || github.ref }}
-          token: ${{ secrets.MOMENTO_MACHINE_USER_GITHUB_TOKEN }}
+          # The Cargo.lock commit below is pushed with the credential checkout
+          # persists, so it has to be the app token.
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Update Cargo.lock
         if: ${{ steps.release.outputs.pr != '' }}
@@ -32,8 +41,8 @@ jobs:
       - name: Commit Cargo.lock
         if: ${{ steps.release.outputs.pr != '' }}
         run: |
-          git config user.name "momento-github-actions-machine-user"
-          git config user.email "87725926+momento-github-actions-machine-user@users.noreply.github.com"
+          git config user.name "momento-release-bot[bot]"
+          git config user.email "momento-release-bot[bot]@users.noreply.github.com"
           git add Cargo.lock
           git diff --staged --quiet || git commit -m "chore: update Cargo.lock for version bump"
           git push


### PR DESCRIPTION
Retires this repo's use of the `MOMENTO_MACHINE_USER_GITHUB_TOKEN` org secret, a
classic PAT on a shared machine user that had to be renewed by hand every 90 days.

- Work that creates a ref, opens a PR, or reaches another repo now mints a
  short-lived installation token from the `momento-release-bot` GitHub App.
  A push or PR authored by the built-in `GITHUB_TOKEN` deliberately does not
  start a workflow run, so release automation needs an app token to keep CI firing.

`MOMENTO_RELEASE_APP_ID` and `MOMENTO_RELEASE_APP_PRIVATE_KEY` are already
provisioned org-wide, so there is no per-repo setup.
